### PR TITLE
Add setting for controlling badge visibility & color

### DIFF
--- a/src/options/App.js
+++ b/src/options/App.js
@@ -8,6 +8,7 @@ const App = () => {
 
   const settings = [
     { name: "general", text: "General" },
+    { name: "badge", text: "Badge" },
     { name: "api", text: "API Token" },
     { name: "sync", text: "Sync" },
     { name: "gmail", text: "Gmail Addon" },
@@ -15,7 +16,6 @@ const App = () => {
 
   return (
     <div className="my-0 mx-auto w-3/5 pt-12">
-      {/*<h1 className="text-2xl text-center text-primary">Settings</h1>*/}
       <h1 className="mb-4 text-2xl text-center font-bold text-gray-900">
         <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#26d6c4] to-[#10b1d3]">
           Settings

--- a/src/options/components/OptionsContent.js
+++ b/src/options/components/OptionsContent.js
@@ -1,4 +1,5 @@
 import OptionsContentGeneral from "./OptionsContentGeneral";
+import OptionsContentBadge from "./OptionsContentBadge";
 import OptionsContentApi from "./OptionsContentApi";
 import OptionsContentSync from "./OptionsContentSync";
 import OptionsContentGmail from "./OptionsContentGmail";
@@ -7,6 +8,8 @@ const OptionsContent = ({ selectedSetting }) => {
   switch (selectedSetting) {
     case "general":
       return <OptionsContentGeneral />;
+    case "badge":
+      return <OptionsContentBadge />;
     case "api":
       return <OptionsContentApi />;
     case "sync":

--- a/src/options/components/OptionsContentBadge.js
+++ b/src/options/components/OptionsContentBadge.js
@@ -1,0 +1,115 @@
+import { useState, useEffect, useCallback } from "react";
+
+import {
+  getStoredBadgeSettings,
+  setStoredBadgeSettings,
+} from "../../utils/storage";
+
+import MarvinButton from "../../components/MarvinButton";
+
+const OptionsContentBadge = () => {
+  const [badgeSettings, setBadgeSettings] = useState({});
+  const [badgeColor, setBadgeColor] = useState("#1CC5CB");
+
+  useEffect(() => {
+    if (Object.keys(badgeSettings).length === 0) {
+      getStoredBadgeSettings().then((settings) => {
+        setBadgeSettings(settings);
+        setBadgeColor(settings.backgroundColor);
+      });
+
+      return;
+    }
+
+    setStoredBadgeSettings(badgeSettings).then(() => {
+      chrome.runtime.sendMessage({
+        message: "toggleBadge",
+      });
+    });
+  }, [badgeSettings]);
+
+  const handleBadgeSetting = (setting, value) => {
+    console.log("handle badge setting", setting, value);
+    setBadgeSettings((prev) => {
+      return {
+        ...prev,
+        [setting]: value,
+      };
+    });
+  };
+
+  const updateBadgeColor = useCallback(() => {
+    handleBadgeSetting("backgroundColor", badgeColor);
+  }, [badgeColor]);
+
+  const resetBadgeColor = useCallback(() => {
+    setBadgeColor("#1CC5CB");
+    handleBadgeSetting("backgroundColor", "#1CC5CB");
+  }, []);
+
+  return (
+    <>
+      <div className="rounded-lg bg-white shadow-lg text-sm">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display Badge</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When this setting is enabled, the badge will be displayed on the
+              extension icon and show the number of tasks scheduled for
+              today.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={badgeSettings?.displayBadge || false}
+                onChange={() =>
+                  handleBadgeSetting(
+                    "displayBadge",
+                    !badgeSettings.displayBadge
+                  )
+                }
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+          {badgeSettings.displayBadge && (
+            <div className="mt-3">
+              <label className="font-bold mb-3" htmlFor="badgeColor">
+                Badge background color
+              </label>
+              <div className="grid grid-cols-2 lg:grid-cols-12 lg:grid-rows-none items-center w-full mt-3 mb-3 gap-1">
+                <p className="lg:col-span-5">
+                  Here you can change the background color of the badge.
+                </p>
+                <div className="w-8 h-8 overflow-hidden rounded-full justify-self-center">
+                  <input
+                    type="color"
+                    id="badgeColor"
+                    value={badgeColor}
+                    onChange={(e) => {
+                      setBadgeColor(e.target.value);
+                    }}
+                    className="w-full h-full bg-white bg-no-repeat bg-padding-box shadow-md transform scale-150 hover:cursor-pointer"
+                  />
+                </div>
+                <div className="lg:col-span-3 flex justify-center">
+                  <MarvinButton onClick={updateBadgeColor}>
+                    Update color
+                  </MarvinButton>
+                </div>
+                <div className="lg:col-span-3 flex justify-center">
+                  <MarvinButton onClick={resetBadgeColor}>
+                    Reset color
+                  </MarvinButton>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OptionsContentBadge;

--- a/src/popup/components/TaskList.js
+++ b/src/popup/components/TaskList.js
@@ -4,6 +4,7 @@ import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import { getTasks } from "../../utils/api";
 import { formatDate } from "../../utils/dates";
 import { setBadge } from "../../utils/badge";
+import { getStoredBadgeSettings } from "../../utils/storage";
 
 import Task from "./Task";
 import TaskListHeader from "./TaskListHeader";
@@ -22,13 +23,16 @@ const TaskList = ({ apiToken, setOnboarded }) => {
         setTasks(tasks);
         setIsLoading(false);
         if (formatDate(day) === formatDate(new Date())) {
-          setBadge(tasks.length);
+          getStoredBadgeSettings().then((badgeSettings) => {
+            if (badgeSettings.displayBadge) {
+              setBadge(tasks.length);
+            }
+          });
         }
       } else {
         setIsLoading(false);
         setIsError(true);
       }
-
     });
   }, [day]);
 

--- a/src/utils/badge.js
+++ b/src/utils/badge.js
@@ -1,11 +1,16 @@
+import { getStoredBadgeSettings } from "./storage";
+
 export function clearBadge() {
   chrome.action.setBadgeText({ text: "" });
 }
 
-export function setBadge(numberOfTasks) {
-  chrome.action.setBadgeBackgroundColor({ color: "#1CC5CB" });
+export async function setBadge(numberOfTasks) {
+  const badgeSettings = await getStoredBadgeSettings();
 
+  // Get the backgroundColor from badgeSettings, or use the default value
+  const backgroundColor = badgeSettings.backgroundColor ?? "#1CC5CB";
+
+  chrome.action.setBadgeBackgroundColor({ color: backgroundColor });
   chrome.action.setBadgeTextColor({ color: "#FFF" });
-
   chrome.action.setBadgeText({ text: `${numberOfTasks}` });
 }

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -125,3 +125,19 @@ export function setStoredGeneralSettings(settings) {
     });
   });
 }
+
+export function getStoredBadgeSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["badgeSettings"]).then((result) => {
+      resolve(result.badgeSettings);
+    });
+  });
+}
+
+export function setStoredBadgeSettings(settings) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ badgeSettings: settings }).then(() => {
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
Adds a new setting to the Settings/Options page for controlling badge visibility and color:

![image](https://user-images.githubusercontent.com/15850530/236128228-3ff51b7b-e370-4764-9284-7dcdc8a5fd90.png)