### PR TITLE
Add selected text to popup

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -60,6 +60,8 @@ chrome.runtime.onInstalled.addListener(() => {
   getStoredGeneralSettings().then((generalSettings) => {
     if (!generalSettings) {
       setStoredGeneralSettings({
+        autoPopulateTaskTitle: false,
+        autoPopulateTaskNote: false,
         displayTaskNoteInput: true,
         displayScheduleDatePicker: true,
         displayDueDatePicker: true,

--- a/src/content_scripts/successMessage.js
+++ b/src/content_scripts/successMessage.js
@@ -49,8 +49,18 @@ marvinSuccessMessage.classList.add(
 );
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.message === "success" || message.message === "fail") {
-    marvinSuccessMessage.textContent = message.message === "success" ? "Task successfully added to Marvin!" : "Failed to add Task to Marvin!";
+  if (message.message === "getPageTitle") {
+    sendResponse({
+      title: document.title,
+      url: window.location.href,
+    });
+  } else if (message.message === "getSelectedText") {
+    sendResponse({ selectedText: window.getSelection().toString() });
+  } else if (message.message === "success" || message.message === "fail") {
+    marvinSuccessMessage.textContent =
+      message.message === "success"
+        ? "Task successfully added to Marvin!"
+        : "Failed to add Task to Marvin!";
     changeClasses();
   }
 });

--- a/src/options/components/OptionsContentGeneral.js
+++ b/src/options/components/OptionsContentGeneral.js
@@ -32,6 +32,56 @@ const OptionsContentGeneral = () => {
     <>
       <div className="rounded-lg bg-white shadow-lg text-sm">
         <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Auto-populate Task Title Input</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When this setting is enabled, the task title will default to the
+              title of the current page.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displaySettings?.autoPopulateTaskTitle || false}
+                onChange={() =>
+                  handleDisplaySetting(
+                    "autoPopulateTaskTitle",
+                    !displaySettings.autoPopulateTaskTitle
+                  )
+                }
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Auto-populate Task Note Input</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When this setting is enabled, the task note will default to select
+              text on the current page.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displaySettings?.autoPopulateTaskNote || false}
+                onChange={() =>
+                  handleDisplaySetting(
+                    "autoPopulateTaskNote",
+                    !displaySettings.autoPopulateTaskNote
+                  )
+                }
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
           <h3 className="font-bold mb-3">Display Task Note input</h3>
           <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
             <p>

--- a/src/popup/components/AddTask.js
+++ b/src/popup/components/AddTask.js
@@ -52,6 +52,45 @@ const AddTask = ({ setOnboarded }) => {
   useEffect(() => {
     getStoredGeneralSettings().then((settings) => {
       setDisplaySettings(settings);
+
+      const {
+        autoPopulateTaskTitle,
+        displayTaskNoteInput,
+        autoPopulateTaskNote,
+      } = settings;
+
+      // Don't overwrite the task title if some text is already saved in local storage
+      if (autoPopulateTaskTitle && taskTitle === "") {
+        // Get the title of the current web page
+        chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+          let url = tabs[0].url;
+          chrome.tabs.sendMessage(
+            tabs[0].id,
+            { message: "getPageTitle" },
+            (response) => {
+              if (response) {
+                setTaskTitle(`[${response.title}](${response.url})`);
+              }
+            }
+          );
+        });
+      }
+      // Don't overwrite the note if some text is already saved in local storage
+      if (displayTaskNoteInput && autoPopulateTaskNote && note === "") {
+        // Get the title of the current web page
+        chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+          let url = tabs[0].url;
+          chrome.tabs.sendMessage(
+            tabs[0].id,
+            { message: "getSelectedText" },
+            (response) => {
+              if (response) {
+                setNote(response.selectedText);
+              }
+            }
+          );
+        });
+      }
     });
   }, []);
 


### PR DESCRIPTION
This PR makes it possible for selected text on the current page to be used to auto-populate the task note input in the pop-up. It also makes it so that the page title is added as a URL to the task title, like `[Page Title](URL)`. The PR also adds two settings to the Options page for enabling/disabling this behavior.

If it happens that the user has already entered something in the task title or note inputs, but hasn't added the task, selected text & page title won't overwrite that input.

Demo:

https://github.com/amazingmarvin/amazingmarvin-browserextension/assets/15850530/2ac91b2b-8cac-4dc3-9edf-472a4612c95e



