### PR TITLE
Add buttons for clearing task title and note.

### DIFF
--- a/src/popup/components/AddTaskNote.js
+++ b/src/popup/components/AddTaskNote.js
@@ -1,9 +1,24 @@
+import { BsX } from "react-icons/bs";
+
 const AddTaskNote = ({ note, setNote }) => {
   return (
     <div>
-      <label className="label">
-        <span className="label-text text-neutral">Task note</span>
-      </label>
+      <div className="flex flex-row items-center gap-0.5">
+        <label className="label">
+          <span className="label-text text-neutral">Task note</span>
+        </label>
+        {note.length > 0 && (
+          <button
+            type="button"
+            className="relative btn btn-xs btn-ghost btn-circle no-animation text-red-500 mb-[0.15rem]"
+            data-hov="clear note"
+            data-pos="C"
+            onClick={() => setNote("")}
+          >
+            <BsX size={18} />
+          </button>
+        )}
+      </div>
       <textarea
         placeholder="Task note..."
         rows={1}

--- a/src/popup/components/AddTaskNote.js
+++ b/src/popup/components/AddTaskNote.js
@@ -1,6 +1,11 @@
+import React from "react";
 import { BsX } from "react-icons/bs";
 
 const AddTaskNote = ({ note, setNote }) => {
+  const select = React.useCallback((e) => {
+    e.target.select();
+  }, []);
+
   return (
     <div>
       <div className="flex flex-row items-center gap-0.5">
@@ -17,6 +22,7 @@ const AddTaskNote = ({ note, setNote }) => {
           onChange={(event) => {
             setNote(event.target.value);
           }}
+          onFocus={select}
         />
 
         {note.length > 0 && (

--- a/src/popup/components/AddTaskNote.js
+++ b/src/popup/components/AddTaskNote.js
@@ -7,27 +7,30 @@ const AddTaskNote = ({ note, setNote }) => {
         <label className="label">
           <span className="label-text text-neutral">Task note</span>
         </label>
+      </div>
+      <div className="relative w-full">
+        <textarea
+          placeholder="Task note..."
+          rows={1}
+          value={note}
+          className="textarea textarea-bordered textarea-primary w-full text-base pr-[30px]"
+          onChange={(event) => {
+            setNote(event.target.value);
+          }}
+        />
+
         {note.length > 0 && (
           <button
             type="button"
-            className="relative btn btn-xs btn-ghost btn-circle no-animation text-red-500 mb-[0.15rem]"
-            data-hov="clear note"
-            data-pos="C"
+            className="absolute right-[8px] top-[8px] padding-4 no-animation text-gray-500"
+            data-hov="Clear note"
+            data-pos="R"
             onClick={() => setNote("")}
           >
-            <BsX size={18} />
+            <BsX size={24} />
           </button>
         )}
       </div>
-      <textarea
-        placeholder="Task note..."
-        rows={1}
-        value={note}
-        className="textarea textarea-bordered textarea-primary w-full text-base"
-        onChange={(event) => {
-          setNote(event.target.value);
-        }}
-      ></textarea>
     </div>
   );
 };

--- a/src/popup/components/AddTaskTitle.js
+++ b/src/popup/components/AddTaskTitle.js
@@ -1,6 +1,11 @@
+import React from "react";
 import { BsX } from "react-icons/bs";
 
 const AddTaskTitle = ({ title, setTaskTitle }) => {
+  const select = React.useCallback((e) => {
+    e.target.select();
+  }, []);
+
   return (
     <div>
       <div className="flex flex-row items-center gap-0.5">
@@ -18,6 +23,7 @@ const AddTaskTitle = ({ title, setTaskTitle }) => {
           placeholder="Enter task title"
           className="input input-bordered input-primary w-full text-base pr-[30px]"
           autoFocus={!title}
+          onFocus={select}
         />
 
         {title.length > 0 && (

--- a/src/popup/components/AddTaskTitle.js
+++ b/src/popup/components/AddTaskTitle.js
@@ -1,9 +1,24 @@
+import { BsX } from "react-icons/bs";
+
 const AddTaskTitle = ({ title, setTaskTitle }) => {
   return (
     <div>
-      <label className="label">
-        <span className="label-text text-neutral">Task title</span>
-      </label>
+      <div className="flex flex-row items-center gap-0.5">
+        <label className="label">
+          <span className="label-text text-neutral">Task title</span>
+        </label>
+        {title.length > 0 && (
+          <button
+            type="button"
+            className="relative btn btn-xs btn-ghost btn-circle no-animation text-red-500 mb-[0.15rem]"
+            data-hov="clear title"
+            data-pos="C"
+            onClick={() => setTaskTitle("")}
+          >
+            <BsX size={18} />
+          </button>
+        )}
+      </div>
       <input
         type="text"
         value={title}

--- a/src/popup/components/AddTaskTitle.js
+++ b/src/popup/components/AddTaskTitle.js
@@ -7,28 +7,31 @@ const AddTaskTitle = ({ title, setTaskTitle }) => {
         <label className="label">
           <span className="label-text text-neutral">Task title</span>
         </label>
+      </div>
+      <div className="relative w-full">
+        <input
+          type="text"
+          value={title}
+          onChange={(event) => {
+            setTaskTitle(event.target.value);
+          }}
+          placeholder="Enter task title"
+          className="input input-bordered input-primary w-full text-base pr-[30px]"
+          autoFocus={!title}
+        />
+
         {title.length > 0 && (
           <button
             type="button"
-            className="relative btn btn-xs btn-ghost btn-circle no-animation text-red-500 mb-[0.15rem]"
-            data-hov="clear title"
-            data-pos="C"
+            className="absolute right-[8px] top-1/2 padding-4 transform -translate-y-1/2 no-animation text-gray-500"
+            data-hov="Clear title"
+            data-pos="R"
             onClick={() => setTaskTitle("")}
           >
-            <BsX size={18} />
+            <BsX size={24} />
           </button>
         )}
       </div>
-      <input
-        type="text"
-        value={title}
-        onChange={(event) => {
-          setTaskTitle(event.target.value);
-        }}
-        placeholder="Enter task title"
-        className="input input-bordered input-primary w-full text-base"
-        autoFocus={!title}
-      />
     </div>
   );
 };


### PR DESCRIPTION
This PR adds buttons for clearing/deleting task title and note. I've noticed that it can be a bit annoying having to select and then delete title/note, especially when the new "auto-populate" feature is enabled.


https://github.com/amazingmarvin/amazingmarvin-browserextension/assets/15850530/4bb1dfed-570e-459f-9210-ba005b45129f

