### PR TITLE
Add group by functionality to Today list.

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -62,6 +62,7 @@ chrome.runtime.onInstalled.addListener(() => {
       setStoredGeneralSettings({
         autoPopulateTaskTitle: false,
         autoPopulateTaskNote: false,
+        groupByMethod: "none",
         displayTaskNoteInput: true,
         displayScheduleDatePicker: true,
         displayDueDatePicker: true,

--- a/src/options/components/OptionsContentGeneral.js
+++ b/src/options/components/OptionsContentGeneral.js
@@ -13,8 +13,8 @@ const OptionsContentGeneral = () => {
   const [groupByExpanded, setGroupByExpanded] = useState(false);
   const groupByMethods = [
     { none: "None" },
-    { dailySection: "Break the Day Down" },
-    { bonusSection: "Just the Essentials" },
+    { dailySection: "Break the Day Down (Morning/Afternoon/Evening)" },
+    { bonusSection: "Just the Essentials (Essential/Bonus)" },
     { customSection: "Custom Sections" },
   ];
 

--- a/src/options/components/OptionsContentGeneral.js
+++ b/src/options/components/OptionsContentGeneral.js
@@ -1,11 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+
 import {
   getStoredGeneralSettings,
   setStoredGeneralSettings,
+  getStoredCustomSections,
 } from "../../utils/storage";
+
+import { getCustomSections, getDefaultCustomSection } from "../../utils/api";
 
 const OptionsContentGeneral = () => {
   const [displaySettings, setDisplaySettings] = useState({});
+  const [groupByExpanded, setGroupByExpanded] = useState(false);
+  const groupByMethods = [
+    { none: "None" },
+    { dailySection: "Break the Day Down" },
+    { bonusSection: "Just the Essentials" },
+    { customSection: "Custom Sections" },
+  ];
 
   useEffect(() => {
     if (Object.keys(displaySettings).length === 0) {
@@ -26,6 +37,31 @@ const OptionsContentGeneral = () => {
         [setting]: value,
       };
     });
+  };
+
+  const fetchCustomSections = useCallback(async () => {
+    await getCustomSections();
+    setTimeout(() => {
+      getDefaultCustomSection();
+    }, 1000);
+  }, []);
+
+  const dropdownText = () => {
+    if (Object.keys(displaySettings).length === 0) {
+      return "None";
+    }
+
+    const groupByMethod = displaySettings.groupByMethod;
+
+    if (groupByMethod === "none") {
+      return "Group by";
+    }
+
+    const groupByMethodObj = groupByMethods.find(
+      (method) => Object.keys(method)[0] === groupByMethod
+    );
+
+    return Object.values(groupByMethodObj)[0];
   };
 
   return (
@@ -77,6 +113,88 @@ const OptionsContentGeneral = () => {
               />
               <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
             </label>
+          </div>
+        </div>
+      </div>
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Group Today list</h3>
+          <div className="flex flex-row items-center justify-between gap-2 w-full mt-3 mb-3">
+            <p className="self-start basis-3/5">
+              Break your daily todo list into sections. Using the dropdown menu,
+              choose which method you would like to use to group your tasks.
+            </p>
+            <div className="self-start basis-2/5 pl-5">
+              <button
+                className="text-white relative w-full bg-[#1CC5CB] hover:bg-[#19B1B6] focus:ring-2 focus:outline-none focus:ring-[#1CC5CB] focus:ring-offset-1 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center"
+                type="button"
+                onClick={() => setGroupByExpanded(!groupByExpanded)}
+              >
+                {dropdownText()}
+                <svg
+                  className="w-2.5 h-2.5 absolute right-3 top-1/2 -translate-y-1/2"
+                  aria-hidden="true"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 10 6"
+                >
+                  <path
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="m1 1 4 4 4-4"
+                  />
+                </svg>
+              </button>
+              <div
+                id="dropdown"
+                className={`${
+                  groupByExpanded ? "block" : "hidden"
+                } z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-full dark:bg-gray-700`}
+              >
+                <ul className="py-2 text-sm text-gray-700 dark:text-gray-200">
+                  {groupByMethods.map((method, index) => {
+                    const keyName = Object.keys(method)[0];
+                    const value = method[keyName];
+
+                    return (
+                      <li key={keyName}>
+                        <a
+                          href="#"
+                          className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
+                          onClick={() => {
+                            handleDisplaySetting("groupByMethod", keyName);
+                            setGroupByExpanded(false);
+
+                            if (keyName === "customSection") {
+                              getStoredCustomSections().then((sections) => {
+                                if (sections.length === 0) {
+                                  fetchCustomSections();
+                                }
+                              });
+                            }
+                          }}
+                        >
+                          {value}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+              {displaySettings.groupByMethod === "customSection" &&
+                !groupByExpanded && (
+                  <div className="text-xs text-center">
+                    <button
+                      className="mt-2 text-primary"
+                      onClick={fetchCustomSections}
+                    >
+                      Update Custom Sections
+                    </button>
+                  </div>
+                )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/options/components/OptionsContentGeneral.js
+++ b/src/options/components/OptionsContentGeneral.js
@@ -140,9 +140,9 @@ const OptionsContentGeneral = () => {
                 >
                   <path
                     stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
                     d="m1 1 4 4 4-4"
                   />
                 </svg>

--- a/src/options/components/OptionsContentGeneral.js
+++ b/src/options/components/OptionsContentGeneral.js
@@ -12,10 +12,10 @@ const OptionsContentGeneral = () => {
   const [displaySettings, setDisplaySettings] = useState({});
   const [groupByExpanded, setGroupByExpanded] = useState(false);
   const groupByMethods = [
-    { none: "None" },
-    { dailySection: "Break the Day Down (Morning/Afternoon/Evening)" },
-    { bonusSection: "Just the Essentials (Essential/Bonus)" },
-    { customSection: "Custom Sections" },
+    { id: "none", title: "None" },
+    { id: "dailySection", title: "Break the Day Down", info: "(Morning/Afternoon/Evening)" },
+    { id: "bonusSection", title: "Just the Essentials", info: "(Essential/Bonus)" },
+    { id: "customSection", title: "Custom" },
   ];
 
   useEffect(() => {
@@ -57,11 +57,11 @@ const OptionsContentGeneral = () => {
       return "Group by";
     }
 
-    const groupByMethodObj = groupByMethods.find(
-      (method) => Object.keys(method)[0] === groupByMethod
-    );
+    const method = groupByMethods.find(
+      (x) => x.id === groupByMethod
+    ) || groupByMethods[0];
 
-    return Object.values(groupByMethodObj)[0];
+    return method.title;
   };
 
   return (
@@ -126,7 +126,7 @@ const OptionsContentGeneral = () => {
             </p>
             <div className="self-start basis-2/5 pl-5">
               <button
-                className="text-white relative w-full bg-[#1CC5CB] hover:bg-[#19B1B6] focus:ring-2 focus:outline-none focus:ring-[#1CC5CB] focus:ring-offset-1 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center"
+                className="text-white relative w-full bg-[#1CC5CB] hover:bg-[#19B1B6] focus:ring-2 focus:outline-none focus:ring-[#1CC5CB] focus:ring-offset-1 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center whitespace-nowrap"
                 type="button"
                 onClick={() => setGroupByExpanded(!groupByExpanded)}
               >
@@ -155,19 +155,18 @@ const OptionsContentGeneral = () => {
               >
                 <ul className="py-2 text-sm text-gray-700 dark:text-gray-200">
                   {groupByMethods.map((method, index) => {
-                    const keyName = Object.keys(method)[0];
-                    const value = method[keyName];
+                    const { id, title, info } = method;
 
                     return (
-                      <li key={keyName}>
+                      <li key={id}>
                         <a
                           href="#"
                           className="block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white"
                           onClick={() => {
-                            handleDisplaySetting("groupByMethod", keyName);
+                            handleDisplaySetting("groupByMethod", id);
                             setGroupByExpanded(false);
 
-                            if (keyName === "customSection") {
+                            if (id === "customSection") {
                               getStoredCustomSections().then((sections) => {
                                 if (sections.length === 0) {
                                   fetchCustomSections();
@@ -176,7 +175,8 @@ const OptionsContentGeneral = () => {
                             }
                           }}
                         >
-                          {value}
+                          {title}
+                          {info && ` ${info}`}
                         </a>
                       </li>
                     );

--- a/src/options/components/OptionsContentGeneral.js
+++ b/src/options/components/OptionsContentGeneral.js
@@ -51,7 +51,7 @@ const OptionsContentGeneral = () => {
       return "None";
     }
 
-    const groupByMethod = displaySettings.groupByMethod;
+    const groupByMethod = displaySettings.groupByMethod || "none";
 
     if (groupByMethod === "none") {
       return "Group by";

--- a/src/popup/components/TaskList.js
+++ b/src/popup/components/TaskList.js
@@ -4,7 +4,12 @@ import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import { getTasks } from "../../utils/api";
 import { formatDate } from "../../utils/dates";
 import { setBadge } from "../../utils/badge";
-import { getStoredBadgeSettings } from "../../utils/storage";
+import {
+  getStoredBadgeSettings,
+  getStoredGeneralSettings,
+  getStoredCustomSections,
+  getStoredDefaultCustomSection,
+} from "../../utils/storage";
 
 import Task from "./Task";
 import TaskListHeader from "./TaskListHeader";
@@ -16,6 +21,11 @@ const TaskList = ({ apiToken, setOnboarded }) => {
   const [isError, setIsError] = useState(false);
   const [day, setDay] = useState(new Date());
   const [displayDate, setDisplayDate] = useState("today");
+  const [groupByMethod, setGroupByMethod] = useState("none"); // Can be "none", "dailyTasks", "bonusSection" or "customSection"
+  const [customSections, setCustomSections] = useState([]);
+  const [defaultCustomSection, setDefaultCustomSection] = useState("");
+  const [collapsedGroups, setCollapsedGroups] = useState({});
+  const [groupedTasks, setGroupedTasks] = useState({});
 
   useEffect(() => {
     getTasks(apiToken, day).then(({ ok, res, tasks }) => {
@@ -53,6 +63,56 @@ const TaskList = ({ apiToken, setOnboarded }) => {
     }
   }, [day, setDisplayDate]);
 
+  // Get settings from storage
+  useEffect(() => {
+    getStoredGeneralSettings().then((generalSettings) => {
+      setGroupByMethod(generalSettings.groupByMethod);
+    });
+    getStoredCustomSections().then((customSections) => {
+      setCustomSections(customSections);
+    });
+    getStoredDefaultCustomSection().then((defaultCustomSection) => {
+      setDefaultCustomSection(defaultCustomSection);
+    });
+  }, []);
+
+  // Group tasks by the selected method
+  // once tasks and settings are loaded
+  useEffect(() => {
+    if (groupByMethod !== "none") {
+      let defaultSection = "";
+      let customSectionLookup = {};
+      let defaultCustomSectionName = "";
+
+      if (groupByMethod === "dailySection") {
+        defaultSection = "Morning";
+      } else if (groupByMethod === "bonusSection") {
+        defaultSection = "Essentials";
+      } else if (groupByMethod === "customSection" && customSections?.length) {
+        customSectionLookup = customSections.reduce((acc, section) => {
+          acc[section.id] = section.title;
+          return acc;
+        }, {});
+        defaultCustomSectionName =
+          customSectionLookup[defaultCustomSection] || "Default section";
+      }
+
+      const sectionInfo = {
+        defaultSection,
+        customSectionLookup,
+        defaultCustomSectionName,
+      };
+
+      const newGroupedTasks = tasks.reduce(
+        groupTasksByKey(groupByMethod, sectionInfo),
+        {}
+      );
+      setGroupedTasks(newGroupedTasks);
+    } else {
+      setGroupedTasks({ none: tasks });
+    }
+  }, [tasks, groupByMethod, customSections, defaultCustomSection]);
+
   const logout = useCallback(() => {
     setStoredToken(null);
     setOnboarded(false);
@@ -63,21 +123,76 @@ const TaskList = ({ apiToken, setOnboarded }) => {
     setTasks(filteredTasks);
   };
 
-  const renderedTasks = tasks.map((task) => {
-    return (
-      <Task
-        task={task}
-        key={task["_id"]}
-        apiToken={apiToken}
-        updateTasks={updateTasks}
-      />
-    );
-  });
+  const groupTasksByKey = (key, sectionInfo) => {
+    return (acc, task) => {
+      let group = task[key];
+      if (key === "customSection") {
+        if (sectionInfo.customSectionLookup[group]) {
+          group = sectionInfo.customSectionLookup[group];
+        } else if (!group && sectionInfo.defaultCustomSectionName) {
+          group = sectionInfo.defaultCustomSectionName;
+        }
+      }
+      group = group || sectionInfo.defaultSection;
+      if (!acc[group]) {
+        acc[group] = [];
+      }
+      acc[group].push(task);
+      return acc;
+    };
+  };
+
+  const toggleCollapse = (group) => {
+    setCollapsedGroups((prevState) => ({
+      ...prevState,
+      [group]: !prevState[group],
+    }));
+  };
+
+  const sectionOrder = {
+    dailySection: ["Morning", "Afternoon", "Evening"],
+    bonusSection: ["Essential", "Bonus"],
+  };
+
+  const renderedTasks = () => {
+    const orderedGroups = Object.keys(groupedTasks).sort((a, b) => {
+      if (groupByMethod in sectionOrder) {
+        return (
+          sectionOrder[groupByMethod].indexOf(a) -
+          sectionOrder[groupByMethod].indexOf(b)
+        );
+      }
+      return 0;
+    });
+
+    return orderedGroups.map((group) => (
+      <div key={group} className="px-2">
+        <h2
+          className="text-primary text-lg font-semibold cursor-pointer pl-2 py-1"
+          onClick={() => toggleCollapse(group)}
+        >
+          {group !== "none" && group}
+          {collapsedGroups[group] && ` (${groupedTasks[group].length})`}
+        </h2>
+        <ul>
+          {!collapsedGroups[group] &&
+            groupedTasks[group].map((task) => (
+              <Task
+                task={task}
+                key={task["_id"]}
+                apiToken={apiToken}
+                updateTasks={updateTasks}
+              />
+            ))}
+        </ul>
+      </div>
+    ));
+  };
 
   return (
     <div
       className={
-        (isLoading || isError)
+        isLoading || isError
           ? "scrollbar-hidden pr-3"
           : "overflow-y-scroll scrollbar-today"
       }
@@ -89,8 +204,12 @@ const TaskList = ({ apiToken, setOnboarded }) => {
             className="p-4 my-2 text-sm text-red-800 rounded-lg bg-red-50"
             role="alert"
           >
-            <span className="font-medium">Error!</span> Failed to load Tasks.
-            If you rotated your API credentials, please <a href="#" onClick={logout}>logout</a>. Otherwise try again or contact support!
+            <span className="font-medium">Error!</span> Failed to load Tasks. If
+            you rotated your API credentials, please{" "}
+            <a href="#" onClick={logout}>
+              logout
+            </a>
+            . Otherwise try again or contact support!
           </div>
         </div>
       ) : isLoading ? (
@@ -98,7 +217,7 @@ const TaskList = ({ apiToken, setOnboarded }) => {
           <LoadingSpinner />
         </div>
       ) : tasks.length ? (
-        <ul className="pb-[30px]">{renderedTasks}</ul>
+        <ul className="pb-[30px]">{renderedTasks()}</ul>
       ) : (
         <div className="h-64 grid place-content-center p-8">
           <h2 className="text-lg">

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -5,6 +5,9 @@ import {
   setLastSyncedLabels,
   setStoredCategories,
   setStoredLabels,
+  setStoredCustomSections,
+  setStoredDefaultCustomSection,
+  setLastSyncedCustomSections,
 } from "./storage";
 
 export const API_OK = "success";
@@ -15,7 +18,7 @@ export function testAPI(token) {
     method: "POST",
     headers: {
       AMVIA: "ext",
-      ...token
+      ...token,
     },
   });
 }
@@ -39,7 +42,7 @@ export async function verifyToken(token) {
     const res = await fetch("https://serv.amazingmarvin.com/api/test", {
       method: "POST",
       headers: {
-      AMVIA: "ext",
+        AMVIA: "ext",
         "X-Full-Access-Token": token,
       },
     });
@@ -151,6 +154,55 @@ export async function getLabels() {
     let labels = await res.json();
     await setLastSyncedLabels();
     return setStoredLabels(labels);
+  }
+
+  if (!res.ok) {
+    console.log(res);
+  }
+}
+
+export async function getCustomSections() {
+  let token = await getStoredToken().then((token) => token);
+
+  const res = await fetch(
+    `https://serv.amazingmarvin.com/api/doc?id=strategySettings.customStructure`,
+    {
+      method: "GET",
+      headers: {
+        AMVIA: "ext",
+        ...token,
+      },
+    }
+  );
+
+  if (res.ok) {
+    let customSections = await res.json();
+    await setLastSyncedCustomSections();
+    return setStoredCustomSections(customSections.val);
+  }
+
+  if (!res.ok) {
+    console.log(res);
+  }
+}
+
+export async function getDefaultCustomSection() {
+  let token = await getStoredToken().then((token) => token);
+
+  const res = await fetch(
+    `https://serv.amazingmarvin.com/api/doc?id=strategySettings.defaultCustomSection`,
+    {
+      method: "GET",
+      headers: {
+        AMVIA: "ext",
+        ...token,
+      },
+    }
+  );
+
+  if (res.ok) {
+    let defaultCustomSection = await res.json();
+    return setStoredDefaultCustomSection(defaultCustomSection.val);
   }
 
   if (!res.ok) {

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,3 +1,5 @@
+import { formatDate } from "./dates";
+
 export function getStoredToken() {
   if (typeof localStorage !== "undefined" && localStorage.apiToken) {
     return Promise.resolve(JSON.parse(localStorage.apiToken));
@@ -33,7 +35,10 @@ export function setStoredToken(apiToken) {
 export function getStoredCategories() {
   return new Promise((resolve) => {
     chrome.storage.local.get(["categories"]).then((result) => {
-      resolve([{ _id: "unassigned", title: "Inbox" }, ...(result.categories || [])]);
+      resolve([
+        { _id: "unassigned", title: "Inbox" },
+        ...(result.categories || []),
+      ]);
     });
   });
 }
@@ -53,6 +58,7 @@ export function getLastSyncedCategories() {
     });
   });
 }
+
 export function setLastSyncedCategories(date = new Date()) {
   return new Promise((resolve) => {
     let syncedTime = `${date.toDateString()} - ${date.toTimeString()}`;
@@ -85,12 +91,64 @@ export function getLastSyncedLabels() {
     });
   });
 }
+
 export function setLastSyncedLabels(date = new Date()) {
   return new Promise((resolve) => {
     let syncedTime = `${date.toDateString()} - ${date.toTimeString()}`;
     chrome.storage.local.set({ lastSyncedLabels: syncedTime }).then(() => {
       resolve();
     });
+  });
+}
+
+export function getStoredCustomSections() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["customSections"]).then((result) => {
+      resolve(result.customSections);
+    });
+  });
+}
+
+export function setStoredCustomSections(sections) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ customSections: sections }).then(() => {
+      resolve();
+    });
+  });
+}
+
+export function getStoredDefaultCustomSection() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["defaultCustomSection"]).then((result) => {
+      resolve(result.defaultCustomSection);
+    });
+  });
+}
+
+export function setStoredDefaultCustomSection(section) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ defaultCustomSection: section }).then(() => {
+      resolve();
+    });
+  });
+}
+
+export function getLastSyncedCustomSections() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["lastSyncedCustomSections"]).then((result) => {
+      resolve(result.lastSyncedCustomSections);
+    });
+  });
+}
+
+export function setLastSyncedCustomSections() {
+  return new Promise((resolve) => {
+    let syncedTime = formatDate(new Date());
+    chrome.storage.local
+      .set({ lastSyncedCustomSections: syncedTime })
+      .then(() => {
+        resolve();
+      });
   });
 }
 


### PR DESCRIPTION
This PR makes it possible to group Today list by:

- Break the day down (morning/afternoon/evening)
- Just the Essentials (essential/bonus)
- Custom Sections

![image](https://github.com/amazingmarvin/amazingmarvin-browserextension/assets/15850530/2a4c4e09-56c2-4733-913d-90359c3c4398)

Method for grouping the list can be found in the General tab in the Settings:

![image](https://github.com/amazingmarvin/amazingmarvin-browserextension/assets/15850530/de749673-dc0a-4fde-a673-0aa4b3a51240)
