### PR TITLE
✨ feat: Add 'Fill with AI' button and enhance context gathering

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -138,6 +138,8 @@ chrome.runtime.onInstalled.addListener(() => {
     if (!settings || Object.keys(settings).length === 0) {
       setStoredAISuggestionsSettings({
         enabled: false,
+        provider: 'anthropic',
+        model: 'claude-3-haiku-20240307',
         apiKey: '',
         showTokenUsage: false,
         cacheEnabled: true,

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -81,22 +81,25 @@ chrome.runtime.onInstalled.addListener(() => {
     }
   });
 
-  chrome.contextMenus.create({
-    id: "addTask",
-    title: "Add task to Marvin",
-    contexts: ["selection"],
-  });
-  chrome.contextMenus.create({
-    id: "addTaskToday",
-    title: "Add task for today",
-    contexts: ["selection"],
-    parentId: "addTask",
-  });
-  chrome.contextMenus.create({
-    id: "addTaskUnscheduled",
-    title: "Add unscheduled task",
-    contexts: ["selection"],
-    parentId: "addTask",
+  // Clear existing context menus before creating new ones to avoid duplicate ID errors
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: "addTask",
+      title: "Add task to Marvin",
+      contexts: ["selection"],
+    });
+    chrome.contextMenus.create({
+      id: "addTaskToday",
+      title: "Add task for today",
+      contexts: ["selection"],
+      parentId: "addTask",
+    });
+    chrome.contextMenus.create({
+      id: "addTaskUnscheduled",
+      title: "Add unscheduled task",
+      contexts: ["selection"],
+      parentId: "addTask",
+    });
   });
 
   chrome.alarms.create({

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -18,6 +18,32 @@ import { clearBadge, setBadge } from "../utils/badge";
 
 console.log("background.js running");
 
+// Create context menus - called on service worker startup
+function setupContextMenus() {
+  chrome.contextMenus.removeAll().then(() => {
+    chrome.contextMenus.create({
+      id: "addTask",
+      title: "Add task to Marvin",
+      contexts: ["selection"],
+    });
+    chrome.contextMenus.create({
+      id: "addTaskToday",
+      title: "Add task for today",
+      contexts: ["selection"],
+      parentId: "addTask",
+    });
+    chrome.contextMenus.create({
+      id: "addTaskUnscheduled",
+      title: "Add unscheduled task",
+      contexts: ["selection"],
+      parentId: "addTask",
+    });
+  });
+}
+
+// Setup context menus on service worker startup
+setupContextMenus();
+
 const addTaskAndSetMessage = (data) => {
   addTask(data).then((message) => {
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
@@ -79,27 +105,6 @@ chrome.runtime.onInstalled.addListener(() => {
         backgroundColor: "#1CC5CB",
       });
     }
-  });
-
-  // Clear existing context menus before creating new ones to avoid duplicate ID errors
-  chrome.contextMenus.removeAll(() => {
-    chrome.contextMenus.create({
-      id: "addTask",
-      title: "Add task to Marvin",
-      contexts: ["selection"],
-    });
-    chrome.contextMenus.create({
-      id: "addTaskToday",
-      title: "Add task for today",
-      contexts: ["selection"],
-      parentId: "addTask",
-    });
-    chrome.contextMenus.create({
-      id: "addTaskUnscheduled",
-      title: "Add unscheduled task",
-      contexts: ["selection"],
-      parentId: "addTask",
-    });
   });
 
   chrome.alarms.create({

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -113,14 +113,16 @@ marvinSuccessMessage.classList.add(
 );
 
 function showSuccessMessage(status) {
-  marvinSuccessMessage.textContent =
-    status === "success"
-      ? "Task successfully added to Marvin!"
-      : "Failed to add Task to Marvin!";
-
-  if (status === "noToken") {
-    marvinSuccessMessage.textContent +=
-      " Please add your Marvin API token in the extension settings.";
+  if (status === "success") {
+    marvinSuccessMessage.textContent = "Task successfully added to Marvin!";
+  } else if (status === "noToken") {
+    marvinSuccessMessage.textContent =
+      "Failed to add Task to Marvin! Please add your Marvin API token in the extension settings.";
+  } else if (status === "reload") {
+    marvinSuccessMessage.textContent =
+      "Extension was updated. Please reload this page to continue using Marvin.";
+  } else {
+    marvinSuccessMessage.textContent = "Failed to add Task to Marvin!";
   }
 
   marvinSuccessMessage.classList.remove("marvinSuccessMessageHidden");
@@ -130,8 +132,20 @@ function showSuccessMessage(status) {
       marvinSuccessMessage.classList.remove("marvinSuccessMessageVisible");
       marvinSuccessMessage.classList.add("marvinSuccessMessageHidden");
     },
-    status === "noToken" ? 6000 : 2000
+    status === "noToken" || status === "reload" ? 6000 : 2000
   );
+}
+
+/**
+ * Checks if extension context is still valid
+ */
+function isExtensionContextValid() {
+  try {
+    chrome.runtime.getURL("");
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 /*
@@ -604,7 +618,21 @@ let useSmartTitles = true;
  * Handles click on Marvin button
  */
 async function handleMarvinButtonClick(metadata) {
-  const token = await getStoredToken();
+  if (!isExtensionContextValid()) {
+    showSuccessMessage("reload");
+    return;
+  }
+
+  let token;
+  try {
+    token = await getStoredToken();
+  } catch (error) {
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+      return;
+    }
+    throw error;
+  }
 
   if (!token) {
     showSuccessMessage("noToken");
@@ -655,7 +683,11 @@ async function handleMarvinButtonClick(metadata) {
     showSuccessMessage(result);
   } catch (error) {
     console.error('Failed to add task to Marvin:', error);
-    showSuccessMessage('fail');
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+    } else {
+      showSuccessMessage('fail');
+    }
   }
 }
 
@@ -663,7 +695,21 @@ async function handleMarvinButtonClick(metadata) {
  * Handles click on Marvin button for comments
  */
 async function handleCommentMarvinButtonClick(metadata) {
-  const token = await getStoredToken();
+  if (!isExtensionContextValid()) {
+    showSuccessMessage("reload");
+    return;
+  }
+
+  let token;
+  try {
+    token = await getStoredToken();
+  } catch (error) {
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+      return;
+    }
+    throw error;
+  }
 
   if (!token) {
     showSuccessMessage("noToken");
@@ -699,7 +745,11 @@ async function handleCommentMarvinButtonClick(metadata) {
     showSuccessMessage(result);
   } catch (error) {
     console.error('Failed to add task to Marvin:', error);
-    showSuccessMessage('fail');
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+    } else {
+      showSuccessMessage('fail');
+    }
   }
 }
 
@@ -707,7 +757,21 @@ async function handleCommentMarvinButtonClick(metadata) {
  * Handles click on Marvin button for notifications
  */
 async function handleNotificationMarvinButtonClick(metadata) {
-  const token = await getStoredToken();
+  if (!isExtensionContextValid()) {
+    showSuccessMessage("reload");
+    return;
+  }
+
+  let token;
+  try {
+    token = await getStoredToken();
+  } catch (error) {
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+      return;
+    }
+    throw error;
+  }
 
   if (!token) {
     showSuccessMessage("noToken");
@@ -738,7 +802,11 @@ async function handleNotificationMarvinButtonClick(metadata) {
     showSuccessMessage(result);
   } catch (error) {
     console.error('Failed to add task to Marvin:', error);
-    showSuccessMessage('fail');
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+    } else {
+      showSuccessMessage('fail');
+    }
   }
 }
 

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -1046,7 +1046,7 @@ function addButtonsToNotifications() {
       display: inline-block;
       vertical-align: middle;
       position: relative;
-      top: 5px;
+      top: 7px;
     `;
     button.onmouseenter = () => {
       button.style.opacity = '1';

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -1044,7 +1044,9 @@ function addButtonsToNotifications() {
       transition: opacity 0.2s, background-color 0.2s;
       flex-shrink: 0;
       display: inline-block;
-      vertical-align: text-bottom;
+      vertical-align: middle;
+      position: relative;
+      top: 2px;
     `;
     button.onmouseenter = () => {
       button.style.opacity = '1';

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -1030,29 +1030,31 @@ function addButtonsToNotifications() {
     button.setAttribute('title', 'Add to Marvin');
     button.setAttribute('type', 'button');
 
-    // Apply notification style
+    // Apply notification style - smaller inline button
     button.style.cssText = `
       background: url(${logo}) no-repeat center center;
-      background-size: 16px 16px;
-      width: 28px;
-      height: 28px;
-      border: 1px solid var(--borderColor-default, rgba(31, 35, 40, 0.15));
-      border-radius: 6px;
+      background-size: 14px 14px;
+      width: 22px;
+      height: 22px;
+      border: none;
+      border-radius: 4px;
       cursor: pointer;
-      margin-left: 8px;
-      transition: background-color 0.2s;
+      margin-right: 6px;
+      opacity: 0.6;
+      transition: opacity 0.2s, background-color 0.2s;
       flex-shrink: 0;
       display: inline-flex;
       align-items: center;
       justify-content: center;
       vertical-align: middle;
-      background-color: var(--bgColor-default, #ffffff);
     `;
     button.onmouseenter = () => {
-      button.style.backgroundColor = 'var(--bgColor-muted, #f6f8fa)';
+      button.style.opacity = '1';
+      button.style.backgroundColor = 'rgba(0, 0, 0, 0.08)';
     };
     button.onmouseleave = () => {
-      button.style.backgroundColor = 'var(--bgColor-default, #ffffff)';
+      button.style.opacity = '0.6';
+      button.style.backgroundColor = 'transparent';
     };
 
     button.onclick = (e) => {
@@ -1061,17 +1063,19 @@ function addButtonsToNotifications() {
       handleNotificationMarvinButtonClick(metadata);
     };
 
-    // Find the meta area or end of row to append
-    const metaArea = notification.querySelector(SELECTORS.notificationMeta);
-    if (metaArea) {
-      metaArea.style.display = 'inline-flex';
-      metaArea.style.alignItems = 'center';
-      metaArea.appendChild(button);
+    // Insert before the title link to keep it inline
+    const titleLink = notification.querySelector(SELECTORS.notificationLink);
+    if (titleLink) {
+      titleLink.parentElement.insertBefore(button, titleLink);
+      addedAny = true;
     } else {
-      notification.appendChild(button);
+      // Fallback: try to find the title element
+      const title = notification.querySelector(SELECTORS.notificationTitle);
+      if (title && title.parentElement) {
+        title.parentElement.insertBefore(button, title);
+        addedAny = true;
+      }
     }
-
-    addedAny = true;
   });
 
   return addedAny;

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -1046,7 +1046,7 @@ function addButtonsToNotifications() {
       display: inline-block;
       vertical-align: middle;
       position: relative;
-      top: 2px;
+      top: 5px;
     `;
     button.onmouseenter = () => {
       button.style.opacity = '1';

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -1,0 +1,725 @@
+import { getStoredGitHubSettings, getStoredToken } from "../utils/storage";
+import { addTask } from "../utils/api";
+import { formatDate } from "../utils/dates";
+
+const logo = chrome.runtime.getURL("static/logo.png");
+
+// GitHub-specific selectors
+const SELECTORS = {
+  // PR Detail View
+  prHeader: '.gh-header-actions',
+  prHeaderMeta: '.gh-header-meta',
+  prTitle: '.js-issue-title',
+  prTitleLink: '.js-issue-title-link',
+  prNumber: '.gh-header-number',
+  prState: '.State',
+  prDescription: '.js-comment-body',
+  prAuthor: '.pull-header-author .author, .author.pull-header-link',
+
+  // Merge status and checks
+  mergeStatusList: '.merge-status-list',
+  statusHeading: '.status-heading',
+  mergeStatusItem: '.merge-status-item',
+  statusIcon: '.octicon',
+
+  // Review status
+  reviewStatus: '.review-status-item',
+  reviewersStatus: '.reviewers-status-icon',
+
+  // PR List View (github.com/pulls and repo pulls page)
+  prListRow: '.js-issue-row',
+  prListTitle: '.Link--primary',
+  prListNumber: '.opened-by',
+  prListRepo: '.text-small a[data-hovercard-type="repository"]',
+
+  // User detection
+  userLogin: 'meta[name="user-login"]',
+  userAvatar: '.AppHeader-user',
+};
+
+/*
+    ***************
+    Success Message
+    ***************
+*/
+
+const marvinSuccessMessage = document.createElement("div");
+document.body.appendChild(marvinSuccessMessage);
+
+let marvinSuccessStyles = document.createElement("style");
+marvinSuccessStyles.appendChild(
+  document.createTextNode(`
+    .marvinSuccessMessageVisible {
+        display: grid;
+        place-items: center;
+    }
+
+    .marvinSuccessMessageHidden {
+        display: none;
+    }
+
+    .marvinSuccessMessage {
+        background: linear-gradient(165deg, #26d6c4 0%, #10b1d3 100%);
+        box-shadow: 0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a;
+        color: white;
+        font-size: 18px;
+        position: fixed !important;
+        bottom: 5%;
+        left: 50%;
+        transform: translate(-50%, 0);
+        width: 350px;
+        height: 75px;
+        z-index: 9999;
+        border-radius: 10px;
+        text-align: center;
+        padding: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }`)
+);
+document.getElementsByTagName("head")[0].appendChild(marvinSuccessStyles);
+
+marvinSuccessMessage.classList.add(
+  "marvinSuccessMessage",
+  "marvinSuccessMessageHidden"
+);
+
+function showSuccessMessage(status) {
+  marvinSuccessMessage.textContent =
+    status === "success"
+      ? "Task successfully added to Marvin!"
+      : "Failed to add Task to Marvin!";
+
+  if (status === "noToken") {
+    marvinSuccessMessage.textContent +=
+      " Please add your Marvin API token in the extension settings.";
+  }
+
+  marvinSuccessMessage.classList.remove("marvinSuccessMessageHidden");
+  marvinSuccessMessage.classList.add("marvinSuccessMessageVisible");
+  setTimeout(
+    () => {
+      marvinSuccessMessage.classList.remove("marvinSuccessMessageVisible");
+      marvinSuccessMessage.classList.add("marvinSuccessMessageHidden");
+    },
+    status === "noToken" ? 6000 : 2000
+  );
+}
+
+/*
+    ***************
+    Metadata Extraction
+    ***************
+*/
+
+/**
+ * Gets the logged-in user's username
+ */
+function getLoggedInUser() {
+  const metaTag = document.querySelector(SELECTORS.userLogin);
+  if (metaTag) {
+    return metaTag.getAttribute('content');
+  }
+  return null;
+}
+
+/**
+ * Extracts PR number from URL
+ */
+function getPRNumberFromUrl() {
+  const match = window.location.pathname.match(/\/pull\/(\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts repository info from URL
+ */
+function getRepositoryFromUrl() {
+  const match = window.location.pathname.match(/\/([^/]+)\/([^/]+)\/pull/);
+  if (match) {
+    return {
+      owner: match[1],
+      repo: match[2],
+      fullName: `${match[1]}/${match[2]}`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Gets check status from merge status area
+ */
+function getCheckStatus() {
+  const mergeStatus = document.querySelector(SELECTORS.mergeStatusList);
+  if (!mergeStatus) return null;
+
+  // Check for failing status
+  if (mergeStatus.querySelector('.octicon-x, .color-fg-danger')) {
+    return 'failing';
+  }
+
+  // Check for pending status
+  if (mergeStatus.querySelector('.octicon-dot-fill, .color-fg-attention')) {
+    return 'pending';
+  }
+
+  // Check for passing status
+  if (mergeStatus.querySelector('.octicon-check, .color-fg-success')) {
+    return 'passing';
+  }
+
+  // Try status heading text
+  const statusHeading = document.querySelector(SELECTORS.statusHeading);
+  if (statusHeading) {
+    const text = statusHeading.textContent.toLowerCase();
+    if (text.includes('failing') || text.includes('failed')) return 'failing';
+    if (text.includes('pending') || text.includes('waiting')) return 'pending';
+    if (text.includes('passing') || text.includes('passed') || text.includes('success')) return 'passing';
+  }
+
+  return null;
+}
+
+/**
+ * Gets review status from reviewers area
+ */
+function getReviewStatus() {
+  const reviewItems = document.querySelectorAll(SELECTORS.reviewStatus);
+  if (!reviewItems.length) return null;
+
+  // Check for changes requested
+  for (const item of reviewItems) {
+    if (item.querySelector('.octicon-file-diff, .color-fg-danger')) {
+      return 'changes_requested';
+    }
+  }
+
+  // Check for approved
+  for (const item of reviewItems) {
+    if (item.querySelector('.octicon-check, .color-fg-success')) {
+      return 'approved';
+    }
+  }
+
+  // Check for pending review
+  for (const item of reviewItems) {
+    if (item.querySelector('.octicon-eye')) {
+      return 'pending';
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Gets PR description (first comment body, truncated)
+ */
+function getPRDescription() {
+  const descElement = document.querySelector(SELECTORS.prDescription);
+  if (!descElement) return '';
+
+  const text = descElement.textContent.trim();
+  return text.length > 500 ? text.substring(0, 497) + '...' : text;
+}
+
+/**
+ * Gets PR metadata from the detail view
+ */
+function getPRMetadataFromDetailView() {
+  const prNumber = getPRNumberFromUrl();
+  if (!prNumber) return null;
+
+  const repository = getRepositoryFromUrl();
+
+  // Get PR title
+  const titleElement = document.querySelector(SELECTORS.prTitle) ||
+                       document.querySelector(SELECTORS.prTitleLink);
+  const prTitle = titleElement ? titleElement.textContent.trim() : 'Pull Request';
+
+  // Get author
+  const authorElement = document.querySelector(SELECTORS.prAuthor);
+  const author = authorElement ? authorElement.textContent.trim() : null;
+
+  // Determine if this is the user's own PR
+  const loggedInUser = getLoggedInUser();
+  const isOwnPR = loggedInUser && author && loggedInUser.toLowerCase() === author.toLowerCase();
+
+  return {
+    prNumber,
+    prTitle,
+    prUrl: window.location.href,
+    author,
+    repository: repository ? repository.fullName : null,
+    checkStatus: getCheckStatus(),
+    reviewStatus: getReviewStatus(),
+    isOwnPR,
+    description: getPRDescription(),
+  };
+}
+
+/**
+ * Gets PR metadata from a list row
+ */
+function getPRMetadataFromListRow(row) {
+  // Get PR title and URL from the link
+  const titleLink = row.querySelector(SELECTORS.prListTitle);
+  if (!titleLink) return null;
+
+  const prTitle = titleLink.textContent.trim();
+  const prUrl = titleLink.href;
+
+  // Extract PR number from URL or text
+  const urlMatch = prUrl.match(/\/pull\/(\d+)/);
+  const prNumber = urlMatch ? urlMatch[1] : null;
+  if (!prNumber) return null;
+
+  // Extract repository from URL
+  const repoMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull/);
+  const repository = repoMatch ? repoMatch[1] : null;
+
+  // Get author - usually in the "opened by" section
+  const openedByElement = row.querySelector(SELECTORS.prListNumber);
+  let author = null;
+  if (openedByElement) {
+    const authorLink = openedByElement.querySelector('a.Link--muted');
+    if (authorLink) {
+      author = authorLink.textContent.trim();
+    }
+  }
+
+  // Determine if this is the user's own PR
+  const loggedInUser = getLoggedInUser();
+  const isOwnPR = loggedInUser && author && loggedInUser.toLowerCase() === author.toLowerCase();
+
+  // Check for status icons in the row
+  let checkStatus = null;
+  if (row.querySelector('.octicon-x, .color-fg-danger')) {
+    checkStatus = 'failing';
+  } else if (row.querySelector('.octicon-dot-fill, .color-fg-attention')) {
+    checkStatus = 'pending';
+  } else if (row.querySelector('.octicon-check, .color-fg-success')) {
+    checkStatus = 'passing';
+  }
+
+  return {
+    prNumber,
+    prTitle,
+    prUrl,
+    author,
+    repository,
+    checkStatus,
+    reviewStatus: null, // Not easily available in list view
+    isOwnPR,
+    description: '', // Not available in list view
+  };
+}
+
+/**
+ * Generates a smart task title based on PR state
+ */
+function getSuggestedTitle(metadata, useSmartTitles) {
+  if (!useSmartTitles) {
+    return `[PR #${metadata.prNumber}: ${metadata.prTitle}](${metadata.prUrl})`;
+  }
+
+  // If not own PR and no review yet, suggest reviewing
+  if (!metadata.isOwnPR && metadata.reviewStatus !== 'approved') {
+    return `[Review PR #${metadata.prNumber}: ${metadata.prTitle}](${metadata.prUrl})`;
+  }
+
+  if (metadata.isOwnPR) {
+    // Own PR with failing checks
+    if (metadata.checkStatus === 'failing') {
+      return `[Fix pipeline for PR #${metadata.prNumber}: ${metadata.prTitle}](${metadata.prUrl})`;
+    }
+
+    // Own PR approved and ready to merge
+    if (metadata.reviewStatus === 'approved' && metadata.checkStatus !== 'failing') {
+      return `[Merge PR #${metadata.prNumber}: ${metadata.prTitle}](${metadata.prUrl})`;
+    }
+
+    // Own PR with changes requested
+    if (metadata.reviewStatus === 'changes_requested') {
+      return `[Address review for PR #${metadata.prNumber}: ${metadata.prTitle}](${metadata.prUrl})`;
+    }
+  }
+
+  // Default format
+  return `[PR #${metadata.prNumber}: ${metadata.prTitle}](${metadata.prUrl})`;
+}
+
+/*
+    ***************
+    Button Creation
+    ***************
+*/
+
+let scheduleForToday = true;
+let useSmartTitles = true;
+
+/**
+ * Handles click on Marvin button
+ */
+async function handleMarvinButtonClick(metadata) {
+  const token = await getStoredToken();
+
+  if (!token) {
+    showSuccessMessage("noToken");
+    return;
+  }
+
+  const data = {
+    title: getSuggestedTitle(metadata, useSmartTitles),
+    done: false,
+  };
+
+  // Build note with PR metadata
+  let noteLines = [':::info'];
+  if (metadata.repository) noteLines.push(`Repository: ${metadata.repository}`);
+  if (metadata.author) noteLines.push(`Author: ${metadata.author}`);
+
+  // Status line
+  const statusParts = [];
+  if (metadata.checkStatus) {
+    const checkLabels = { passing: 'Checks passing', failing: 'Checks failing', pending: 'Checks pending' };
+    statusParts.push(checkLabels[metadata.checkStatus]);
+  }
+  if (metadata.reviewStatus) {
+    const reviewLabels = { approved: 'Approved', changes_requested: 'Changes requested', pending: 'Review pending' };
+    statusParts.push(reviewLabels[metadata.reviewStatus]);
+  }
+  if (statusParts.length > 0) {
+    noteLines.push(`Status: ${statusParts.join(' | ')}`);
+  }
+
+  if (metadata.description) {
+    noteLines.push('');
+    noteLines.push('Description:');
+    noteLines.push(metadata.description);
+  }
+
+  noteLines.push('');
+  noteLines.push(`[View on GitHub](${metadata.prUrl})`);
+
+  data.note = noteLines.join('\n');
+
+  if (scheduleForToday) {
+    data.day = formatDate(new Date());
+  }
+
+  try {
+    const result = await addTask(data);
+    showSuccessMessage(result);
+  } catch (error) {
+    console.error('Failed to add task to Marvin:', error);
+    showSuccessMessage('fail');
+  }
+}
+
+/**
+ * Creates a Marvin button for GitHub
+ */
+function createMarvinButton(metadata, style = 'header') {
+  const button = document.createElement('button');
+  button.classList.add('marvinButton');
+  button.setAttribute('data-marvin-pr', metadata.prNumber);
+  button.setAttribute('aria-label', 'Add to Marvin');
+  button.setAttribute('type', 'button');
+
+  // Build tooltip with check status
+  let tooltip = 'Add to Marvin';
+  if (metadata.checkStatus) {
+    const statusText = { passing: 'Checks passing', failing: 'Checks failing', pending: 'Checks pending' };
+    tooltip += ` (${statusText[metadata.checkStatus]})`;
+  }
+  button.setAttribute('title', tooltip);
+
+  if (style === 'header') {
+    // Style for PR detail view header - matches GitHub's button style
+    button.style.cssText = `
+      background: url(${logo}) no-repeat center center;
+      background-size: 16px 16px;
+      width: 32px;
+      height: 32px;
+      border: 1px solid var(--borderColor-default, rgba(31, 35, 40, 0.15));
+      border-radius: 6px;
+      cursor: pointer;
+      margin-left: 8px;
+      transition: background-color 0.2s;
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      vertical-align: middle;
+      background-color: var(--bgColor-default, #ffffff);
+    `;
+    button.onmouseenter = () => {
+      button.style.backgroundColor = 'var(--bgColor-muted, #f6f8fa)';
+    };
+    button.onmouseleave = () => {
+      button.style.backgroundColor = 'var(--bgColor-default, #ffffff)';
+    };
+  } else if (style === 'list') {
+    // Style for PR list rows - smaller, inline button
+    button.style.cssText = `
+      background: url(${logo}) no-repeat center center;
+      background-size: 14px 14px;
+      width: 24px;
+      height: 24px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      opacity: 0.6;
+      transition: opacity 0.2s, background-color 0.2s;
+      flex-shrink: 0;
+      margin-left: 8px;
+    `;
+    button.onmouseenter = () => {
+      button.style.opacity = '1';
+      button.style.backgroundColor = 'rgba(0, 0, 0, 0.05)';
+    };
+    button.onmouseleave = () => {
+      button.style.opacity = '0.6';
+      button.style.backgroundColor = 'transparent';
+    };
+  }
+
+  button.onclick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleMarvinButtonClick(metadata);
+  };
+
+  return button;
+}
+
+/*
+    ***************
+    Button Injection
+    ***************
+*/
+
+/**
+ * Checks if Marvin button already exists
+ */
+function marvinButtonExists(container, prNumber) {
+  return container.querySelector(`.marvinButton[data-marvin-pr="${prNumber}"]`) !== null;
+}
+
+/**
+ * Adds Marvin button to PR detail view
+ */
+function addButtonToPRDetailView() {
+  const metadata = getPRMetadataFromDetailView();
+  if (!metadata) return false;
+
+  // Don't add if already exists
+  if (marvinButtonExists(document.body, metadata.prNumber)) return true;
+
+  const button = createMarvinButton(metadata, 'header');
+
+  // Primary: Add to header actions area
+  const headerActions = document.querySelector(SELECTORS.prHeader);
+  if (headerActions) {
+    headerActions.appendChild(button);
+    return true;
+  }
+
+  // Fallback: Add near PR title/number
+  const prMeta = document.querySelector(SELECTORS.prHeaderMeta);
+  if (prMeta) {
+    const wrapper = document.createElement('span');
+    wrapper.style.cssText = 'display: inline-flex; align-items: center; margin-left: 8px;';
+    wrapper.appendChild(button);
+    prMeta.appendChild(wrapper);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Adds Marvin buttons to PR list rows
+ */
+function addButtonsToPRList() {
+  const rows = document.querySelectorAll(SELECTORS.prListRow);
+
+  if (!rows || rows.length === 0) return false;
+
+  let addedAny = false;
+
+  rows.forEach(row => {
+    const metadata = getPRMetadataFromListRow(row);
+    if (!metadata) return;
+
+    if (marvinButtonExists(row, metadata.prNumber)) return;
+
+    const button = createMarvinButton(metadata, 'list');
+
+    // Find the title element and add button after it
+    const titleElement = row.querySelector(SELECTORS.prListTitle);
+    if (titleElement && titleElement.parentElement) {
+      titleElement.parentElement.style.display = 'inline-flex';
+      titleElement.parentElement.style.alignItems = 'center';
+      titleElement.after(button);
+      addedAny = true;
+      return;
+    }
+
+    // Fallback: append to row
+    row.appendChild(button);
+    addedAny = true;
+  });
+
+  return addedAny;
+}
+
+/*
+    ***************
+    Main Logic
+    ***************
+*/
+
+let enabled = true;
+let displayInPRView = true;
+let displayInPRList = true;
+let isInitialized = false;
+let observer = null;
+
+/**
+ * Determines current view type and adds appropriate buttons
+ */
+function addButtonsToCurrentView() {
+  const url = window.location.href;
+  let added = false;
+
+  // PR detail view (github.com/owner/repo/pull/123)
+  if (url.match(/\/pull\/\d+/) && displayInPRView) {
+    added = addButtonToPRDetailView() || added;
+  }
+
+  // PR list view (github.com/pulls or github.com/owner/repo/pulls)
+  if ((url.includes('/pulls') || url.endsWith('/pulls')) && displayInPRList) {
+    added = addButtonsToPRList() || added;
+  }
+
+  return added;
+}
+
+/**
+ * Debounce function
+ */
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+}
+
+const debouncedAddButtons = debounce(addButtonsToCurrentView, 250);
+
+/**
+ * Handles DOM mutations - watches for new PR elements
+ */
+function handleMutation(mutationsList) {
+  for (const mutation of mutationsList) {
+    if (mutation.type !== 'childList' || mutation.addedNodes.length === 0) continue;
+
+    for (const node of mutation.addedNodes) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+      // Check if this is or contains PR-related elements
+      if (node.matches?.(SELECTORS.prHeader) ||
+          node.matches?.(SELECTORS.prListRow) ||
+          node.querySelector?.(SELECTORS.prHeader) ||
+          node.querySelector?.(SELECTORS.prListRow) ||
+          node.querySelector?.(SELECTORS.prTitle)) {
+        debouncedAddButtons();
+        return;
+      }
+    }
+  }
+}
+
+/**
+ * Checks if GitHub page has loaded
+ */
+function isGitHubLoaded() {
+  return document.querySelector(SELECTORS.prTitle) ||
+         document.querySelector(SELECTORS.prListRow) ||
+         document.querySelector('.repository-content') ||
+         document.querySelector('[data-turbo-body]');
+}
+
+/**
+ * Initializes the content script
+ */
+async function init() {
+  // Load settings
+  const settings = await getStoredGitHubSettings();
+  enabled = settings.enabled ?? true;
+  scheduleForToday = settings.scheduleForToday ?? true;
+  displayInPRView = settings.displayInPRView ?? true;
+  displayInPRList = settings.displayInPRList ?? true;
+  useSmartTitles = settings.useSmartTitles ?? true;
+
+  // If disabled, don't proceed
+  if (!enabled) {
+    clearInterval(loopInterval);
+    return;
+  }
+
+  // If all display options are disabled, don't proceed
+  if (!displayInPRView && !displayInPRList) {
+    clearInterval(loopInterval);
+    return;
+  }
+
+  // Wait for GitHub to load
+  if (!isGitHubLoaded() && !isInitialized) {
+    return;
+  }
+
+  // Add buttons to current view
+  addButtonsToCurrentView();
+
+  if (!isInitialized) {
+    isInitialized = true;
+
+    // Set up MutationObserver for dynamic content
+    observer = new MutationObserver(handleMutation);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Handle Turbo navigation (GitHub's SPA-like navigation)
+    document.addEventListener('turbo:load', () => {
+      debouncedAddButtons();
+    });
+
+    document.addEventListener('turbo:render', () => {
+      debouncedAddButtons();
+    });
+
+    // Also listen for popstate (back/forward navigation)
+    window.addEventListener('popstate', () => {
+      debouncedAddButtons();
+    });
+
+    // Stop the initial interval
+    clearInterval(loopInterval);
+
+    console.log('Marvin GitHub PR integration initialized');
+  }
+}
+
+// Start initialization loop
+const loopInterval = setInterval(init, 1000);
+
+// Also try to initialize immediately if DOM is ready
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  init();
+}

--- a/src/content_scripts/github-pr.js
+++ b/src/content_scripts/github-pr.js
@@ -1034,8 +1034,8 @@ function addButtonsToNotifications() {
     button.style.cssText = `
       background: url(${logo}) no-repeat center center;
       background-size: 14px 14px;
-      width: 22px;
-      height: 22px;
+      width: 20px;
+      height: 20px;
       border: none;
       border-radius: 4px;
       cursor: pointer;
@@ -1043,10 +1043,8 @@ function addButtonsToNotifications() {
       opacity: 0.6;
       transition: opacity 0.2s, background-color 0.2s;
       flex-shrink: 0;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      vertical-align: middle;
+      display: inline-block;
+      vertical-align: text-bottom;
     `;
     button.onmouseenter = () => {
       button.style.opacity = '1';

--- a/src/content_scripts/jira.js
+++ b/src/content_scripts/jira.js
@@ -1,0 +1,659 @@
+import { getStoredJiraSettings, getStoredToken } from "../utils/storage";
+import { addTask } from "../utils/api";
+import { formatDate } from "../utils/dates";
+
+const logo = chrome.runtime.getURL("static/logo.png");
+
+// Jira-specific selectors (using data-testid for stability where possible)
+const SELECTORS = {
+  // Issue detail view
+  issueView: '[data-testid="issue.views.issue-base.foundation.summary.heading"]',
+  issueKey: '[data-testid="issue.views.issue-base.foundation.breadcrumbs.current-issue.item"]',
+  issueTitle: '[data-testid="issue.views.issue-base.foundation.summary.heading"]',
+  issueDescription: '[data-testid="issue.views.field.rich-text.description"]',
+  issueToolbar: '[data-testid="issue.views.issue-base.foundation.quick-add.button"]',
+
+  // Board view cards
+  boardCard: '[data-testid="platform-board-kit.ui.card.card"]',
+  cardKey: '[data-testid="platform-card.common.ui.key.key"]',
+  cardSummary: '[data-testid="platform-card.common.ui.summary.card-summary"]',
+
+  // Backlog/list view
+  backlogRow: '[data-testid="software-backlog.card-list.card"]',
+  listIssueKey: '[data-testid="software-backlog.card-list.card.key"]',
+
+  // Alternative selectors for different Jira versions
+  issueKeyAlt: '[data-testid*="issue-key"], [data-testid*="breadcrumbs"] a',
+  issueTitleAlt: 'h1[data-testid*="summary"], [data-testid*="summary"] h1',
+  boardCardAlt: '[data-rbd-draggable-id], .ghx-issue',
+};
+
+/*
+    ***************
+    Success Message
+    ***************
+*/
+
+const marvinSuccessMessage = document.createElement("div");
+document.body.appendChild(marvinSuccessMessage);
+
+let marvinSuccessStyles = document.createElement("style");
+marvinSuccessStyles.appendChild(
+  document.createTextNode(`
+    .marvinSuccessMessageVisible {
+        display: grid;
+        place-items: center;
+    }
+
+    .marvinSuccessMessageHidden {
+        display: none;
+    }
+
+    .marvinSuccessMessage {
+        background: linear-gradient(165deg, #26d6c4 0%, #10b1d3 100%);
+        box-shadow: 0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a;
+        color: white;
+        font-size: 18px;
+        position: fixed !important;
+        bottom: 5%;
+        left: 50%;
+        transform: translate(-50%, 0);
+        width: 350px;
+        height: 75px;
+        z-index: 9999;
+        border-radius: 10px;
+        text-align: center;
+        padding: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }`)
+);
+document.getElementsByTagName("head")[0].appendChild(marvinSuccessStyles);
+
+marvinSuccessMessage.classList.add(
+  "marvinSuccessMessage",
+  "marvinSuccessMessageHidden"
+);
+
+function showSuccessMessage(status) {
+  marvinSuccessMessage.textContent =
+    status === "success"
+      ? "Task successfully added to Marvin!"
+      : "Failed to add Task to Marvin!";
+
+  if (status === "noToken") {
+    marvinSuccessMessage.textContent +=
+      " Please add your Marvin API token in the extension settings.";
+  }
+
+  marvinSuccessMessage.classList.remove("marvinSuccessMessageHidden");
+  marvinSuccessMessage.classList.add("marvinSuccessMessageVisible");
+  setTimeout(
+    () => {
+      marvinSuccessMessage.classList.remove("marvinSuccessMessageVisible");
+      marvinSuccessMessage.classList.add("marvinSuccessMessageHidden");
+    },
+    status === "noToken" ? 6000 : 2000
+  );
+}
+
+/*
+    ***************
+    Metadata Extraction
+    ***************
+*/
+
+/**
+ * Extracts issue key from URL
+ */
+function getIssueKeyFromUrl() {
+  // Check for /browse/PROJ-123 pattern
+  const browseMatch = window.location.href.match(/\/browse\/([A-Z][A-Z0-9]*-\d+)/i);
+  if (browseMatch) return browseMatch[1].toUpperCase();
+
+  // Check for selectedIssue in query params (board view detail panel)
+  const params = new URLSearchParams(window.location.search);
+  const selectedIssue = params.get('selectedIssue');
+  if (selectedIssue && /^[A-Z][A-Z0-9]*-\d+$/i.test(selectedIssue)) {
+    return selectedIssue.toUpperCase();
+  }
+
+  return null;
+}
+
+/**
+ * Extracts issue key from a DOM element
+ */
+function getIssueKeyFromElement(element) {
+  // Try data-testid selectors first
+  const keyElement = element.querySelector(SELECTORS.cardKey) ||
+                     element.querySelector(SELECTORS.issueKey) ||
+                     element.querySelector(SELECTORS.listIssueKey) ||
+                     element.querySelector(SELECTORS.issueKeyAlt);
+
+  if (keyElement) {
+    const text = keyElement.textContent.trim();
+    const match = text.match(/[A-Z][A-Z0-9]*-\d+/i);
+    if (match) return match[0].toUpperCase();
+  }
+
+  // Try to find any element with issue key pattern in links
+  const links = element.querySelectorAll('a[href*="/browse/"]');
+  for (const link of links) {
+    const hrefMatch = link.href.match(/\/browse\/([A-Z][A-Z0-9]*-\d+)/i);
+    if (hrefMatch) return hrefMatch[1].toUpperCase();
+  }
+
+  // Last resort: search text content
+  const allText = element.textContent;
+  const match = allText.match(/\b([A-Z][A-Z0-9]*-\d+)\b/i);
+  return match ? match[1].toUpperCase() : null;
+}
+
+/**
+ * Gets issue summary/title from DOM
+ */
+function getIssueSummary(element) {
+  // For issue detail view
+  const titleElement = document.querySelector(SELECTORS.issueTitle) ||
+                       document.querySelector(SELECTORS.issueTitleAlt) ||
+                       document.querySelector('h1');
+
+  if (titleElement && !element) {
+    return titleElement.textContent.trim();
+  }
+
+  // For card/list elements
+  if (element) {
+    const cardSummary = element.querySelector(SELECTORS.cardSummary) ||
+                        element.querySelector('[data-testid*="summary"]') ||
+                        element.querySelector('.ghx-summary');
+
+    if (cardSummary) return cardSummary.textContent.trim();
+
+    // Try to find summary in nearby elements
+    const summarySpan = element.querySelector('span[class*="summary"], [class*="title"]');
+    if (summarySpan) return summarySpan.textContent.trim();
+  }
+
+  return 'Jira Issue';
+}
+
+/**
+ * Gets issue description (truncated to 500 chars)
+ */
+function getIssueDescription() {
+  const descElement = document.querySelector(SELECTORS.issueDescription) ||
+                      document.querySelector('[data-testid*="description"]');
+
+  if (!descElement) return '';
+
+  const text = descElement.textContent.trim();
+  return text.length > 500 ? text.substring(0, 497) + '...' : text;
+}
+
+/**
+ * Gets issue type from the page
+ */
+function getIssueType() {
+  const typeElement = document.querySelector('[data-testid*="issue-type-icon"]') ||
+                      document.querySelector('[data-testid*="issue-type"]') ||
+                      document.querySelector('[aria-label*="Type:"]') ||
+                      document.querySelector('[data-testid*="type"]');
+
+  if (typeElement) {
+    // Try aria-label first as it often has the type name
+    const ariaLabel = typeElement.getAttribute('aria-label');
+    if (ariaLabel) {
+      const match = ariaLabel.match(/(?:Type:|Issue Type:)?\s*(.+)/i);
+      if (match) return match[1].trim();
+    }
+    return typeElement.textContent.trim() || 'Task';
+  }
+
+  return 'Task';
+}
+
+/**
+ * Gets issue priority from the page
+ */
+function getIssuePriority() {
+  const priorityElement = document.querySelector('[data-testid*="priority"]') ||
+                          document.querySelector('[aria-label*="Priority:"]');
+
+  if (priorityElement) {
+    const ariaLabel = priorityElement.getAttribute('aria-label');
+    if (ariaLabel) {
+      const match = ariaLabel.match(/Priority:\s*(.+)/i);
+      if (match) return match[1].trim();
+    }
+    return priorityElement.textContent.trim();
+  }
+
+  return '';
+}
+
+/**
+ * Builds complete Jira issue metadata
+ */
+function getJiraMetadata(element = null) {
+  const issueKey = element ? getIssueKeyFromElement(element) : getIssueKeyFromUrl();
+
+  if (!issueKey) return null;
+
+  const baseUrl = window.location.origin;
+  const issueUrl = `${baseUrl}/browse/${issueKey}`;
+
+  return {
+    issueKey,
+    summary: getIssueSummary(element),
+    description: getIssueDescription(),
+    issueUrl,
+    issueType: getIssueType(),
+    priority: getIssuePriority(),
+  };
+}
+
+/*
+    ***************
+    Button Creation
+    ***************
+*/
+
+let scheduleForToday = true;
+
+/**
+ * Handles click on Marvin button
+ */
+async function handleMarvinButtonClick(metadata) {
+  const token = await getStoredToken();
+
+  if (!token) {
+    showSuccessMessage("noToken");
+    return;
+  }
+
+  const data = {
+    title: `[${metadata.issueKey}: ${metadata.summary}](${metadata.issueUrl})`,
+    done: false,
+  };
+
+  // Build note with issue metadata
+  let noteLines = [':::info'];
+  if (metadata.issueType) noteLines.push(`Issue Type: ${metadata.issueType}`);
+  if (metadata.priority) noteLines.push(`Priority: ${metadata.priority}`);
+  if (metadata.description) {
+    noteLines.push('');
+    noteLines.push('Description:');
+    noteLines.push(metadata.description);
+  }
+  data.note = noteLines.join('\n');
+
+  if (scheduleForToday) {
+    data.day = formatDate(new Date());
+  }
+
+  try {
+    const result = await addTask(data);
+    showSuccessMessage(result);
+  } catch (error) {
+    console.error('Failed to add task to Marvin:', error);
+    showSuccessMessage('fail');
+  }
+}
+
+/**
+ * Creates a Marvin button for Jira
+ */
+function createMarvinButton(metadata, style = 'toolbar') {
+  const button = document.createElement('button');
+  button.classList.add('marvinButton');
+  button.setAttribute('data-marvin-issue', metadata.issueKey);
+  button.setAttribute('aria-label', 'Add to Marvin');
+  button.setAttribute('title', 'Add to Marvin');
+  button.setAttribute('type', 'button');
+
+  if (style === 'toolbar') {
+    // Style for issue detail view toolbar
+    button.style.cssText = `
+      background: url(${logo}) no-repeat center center;
+      background-size: 20px 20px;
+      width: 32px;
+      height: 32px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      margin-left: 8px;
+      transition: background-color 0.2s;
+      flex-shrink: 0;
+    `;
+    button.onmouseenter = () => { button.style.backgroundColor = 'rgba(0, 0, 0, 0.1)'; };
+    button.onmouseleave = () => { button.style.backgroundColor = 'transparent'; };
+  } else if (style === 'card') {
+    // Style for board cards
+    button.style.cssText = `
+      background: url(${logo}) no-repeat center center;
+      background-size: 16px 16px;
+      background-color: white;
+      width: 24px;
+      height: 24px;
+      border: 1px solid #dfe1e6;
+      border-radius: 3px;
+      cursor: pointer;
+      opacity: 0.8;
+      transition: opacity 0.2s, box-shadow 0.2s;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    `;
+    button.onmouseenter = () => {
+      button.style.opacity = '1';
+      button.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
+    };
+    button.onmouseleave = () => {
+      button.style.opacity = '0.8';
+      button.style.boxShadow = '0 1px 2px rgba(0,0,0,0.1)';
+    };
+  } else if (style === 'list') {
+    // Style for list/backlog rows
+    button.style.cssText = `
+      background: url(${logo}) no-repeat center center;
+      background-size: 16px 16px;
+      width: 24px;
+      height: 24px;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      margin-left: 4px;
+      opacity: 0.7;
+      transition: opacity 0.2s;
+    `;
+    button.onmouseenter = () => { button.style.opacity = '1'; };
+    button.onmouseleave = () => { button.style.opacity = '0.7'; };
+  }
+
+  button.onclick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleMarvinButtonClick(metadata);
+  };
+
+  return button;
+}
+
+/*
+    ***************
+    Button Injection
+    ***************
+*/
+
+/**
+ * Checks if Marvin button already exists for an issue
+ */
+function marvinButtonExists(container, issueKey) {
+  return container.querySelector(`.marvinButton[data-marvin-issue="${issueKey}"]`) !== null;
+}
+
+/**
+ * Adds Marvin button to issue detail view
+ */
+function addButtonToIssueView() {
+  // Find the issue view header/summary area
+  const issueView = document.querySelector(SELECTORS.issueView) ||
+                    document.querySelector(SELECTORS.issueTitleAlt);
+
+  if (!issueView) return false;
+
+  const metadata = getJiraMetadata();
+  if (!metadata) return false;
+
+  // Don't add if already exists
+  if (marvinButtonExists(document.body, metadata.issueKey)) return true;
+
+  // Find the header area containing the title
+  const headerArea = issueView.closest('[data-testid*="header"]') ||
+                     issueView.closest('[data-testid*="foundation"]') ||
+                     issueView.parentElement?.parentElement;
+
+  if (!headerArea) return false;
+
+  // Look for action buttons area or create insertion point
+  let actionArea = headerArea.querySelector('[data-testid*="actions"]') ||
+                   headerArea.querySelector('[role="group"]') ||
+                   headerArea.querySelector('div:last-child');
+
+  const button = createMarvinButton(metadata, 'toolbar');
+
+  // Try to find a good place to insert
+  if (actionArea && actionArea !== headerArea) {
+    actionArea.appendChild(button);
+  } else {
+    // Insert after the title element
+    issueView.parentElement.appendChild(button);
+  }
+
+  return true;
+}
+
+/**
+ * Adds Marvin buttons to board cards
+ */
+function addButtonsToBoardCards() {
+  const cards = document.querySelectorAll(SELECTORS.boardCard) ||
+                document.querySelectorAll(SELECTORS.boardCardAlt);
+
+  if (!cards || cards.length === 0) return false;
+
+  let addedAny = false;
+
+  cards.forEach(card => {
+    const metadata = getJiraMetadata(card);
+    if (!metadata) return;
+
+    if (marvinButtonExists(card, metadata.issueKey)) return;
+
+    // Find or create card actions area
+    let actionsArea = card.querySelector('.marvin-actions-area');
+
+    if (!actionsArea) {
+      actionsArea = document.createElement('div');
+      actionsArea.style.cssText = `
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        display: none;
+        z-index: 10;
+      `;
+      actionsArea.classList.add('marvin-actions-area');
+
+      // Make card position relative if not already
+      const cardStyle = getComputedStyle(card);
+      if (cardStyle.position === 'static') {
+        card.style.position = 'relative';
+      }
+
+      card.appendChild(actionsArea);
+
+      // Show on hover
+      card.addEventListener('mouseenter', () => {
+        actionsArea.style.display = 'block';
+      });
+      card.addEventListener('mouseleave', () => {
+        actionsArea.style.display = 'none';
+      });
+    }
+
+    const button = createMarvinButton(metadata, 'card');
+    actionsArea.appendChild(button);
+    addedAny = true;
+  });
+
+  return addedAny;
+}
+
+/**
+ * Adds Marvin buttons to backlog/list rows
+ */
+function addButtonsToListView() {
+  const rows = document.querySelectorAll(SELECTORS.backlogRow);
+
+  if (!rows || rows.length === 0) return false;
+
+  let addedAny = false;
+
+  rows.forEach(row => {
+    const metadata = getJiraMetadata(row);
+    if (!metadata) return;
+
+    if (marvinButtonExists(row, metadata.issueKey)) return;
+
+    // Find or create row actions area
+    let actionsArea = row.querySelector('.marvin-list-actions');
+
+    if (!actionsArea) {
+      actionsArea = document.createElement('div');
+      actionsArea.classList.add('marvin-list-actions');
+      actionsArea.style.cssText = `
+        display: inline-flex;
+        align-items: center;
+        margin-left: 8px;
+      `;
+      row.appendChild(actionsArea);
+    }
+
+    const button = createMarvinButton(metadata, 'list');
+    actionsArea.appendChild(button);
+    addedAny = true;
+  });
+
+  return addedAny;
+}
+
+/*
+    ***************
+    Main Logic
+    ***************
+*/
+
+let displayInIssueView = true;
+let displayInBoardView = true;
+let displayInListView = true;
+let isInitialized = false;
+let observer = null;
+
+/**
+ * Determines current view type and adds appropriate buttons
+ */
+function addButtonsToCurrentView() {
+  const url = window.location.href;
+  let added = false;
+
+  // Issue detail view (browse page or selected issue in side panel)
+  if ((url.includes('/browse/') || url.includes('selectedIssue=')) && displayInIssueView) {
+    added = addButtonToIssueView() || added;
+  }
+
+  // Board view
+  if ((url.includes('/board') || url.includes('/boards/')) && displayInBoardView) {
+    added = addButtonsToBoardCards() || added;
+  }
+
+  // Backlog/list view
+  if (url.includes('/backlog') && displayInListView) {
+    added = addButtonsToListView() || added;
+  }
+
+  return added;
+}
+
+/**
+ * Debounce function to limit frequent calls
+ */
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
+
+const debouncedAddButtons = debounce(addButtonsToCurrentView, 300);
+
+/**
+ * Handles DOM mutations
+ */
+function handleMutation(mutationsList) {
+  for (const mutation of mutationsList) {
+    if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+      debouncedAddButtons();
+      break; // Only need to trigger once per batch
+    }
+  }
+}
+
+/**
+ * Checks if Jira has loaded
+ */
+function isJiraLoaded() {
+  return document.querySelector('[data-testid*="navigation"]') ||
+         document.querySelector('#jira-frontend') ||
+         document.querySelector('[id*="jira"]') ||
+         document.querySelector('[data-testid*="software"]');
+}
+
+/**
+ * Initializes the content script
+ */
+async function init() {
+  // Load settings
+  const settings = await getStoredJiraSettings();
+  displayInIssueView = settings.displayInIssueView ?? true;
+  displayInBoardView = settings.displayInBoardView ?? true;
+  displayInListView = settings.displayInListView ?? true;
+  scheduleForToday = settings.scheduleForToday ?? true;
+
+  // If all display options are disabled, don't proceed
+  if (!displayInIssueView && !displayInBoardView && !displayInListView) {
+    clearInterval(loopInterval);
+    return;
+  }
+
+  // Wait for Jira to load
+  if (!isJiraLoaded() && !isInitialized) {
+    return; // Wait for Jira to load
+  }
+
+  // Add buttons to current view
+  addButtonsToCurrentView();
+
+  if (!isInitialized) {
+    isInitialized = true;
+
+    // Set up MutationObserver for SPA navigation
+    observer = new MutationObserver(handleMutation);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Also listen for URL changes (popstate for back/forward navigation)
+    window.addEventListener('popstate', debouncedAddButtons);
+
+    // Listen for hashchange as well
+    window.addEventListener('hashchange', debouncedAddButtons);
+
+    // Stop the initial interval
+    clearInterval(loopInterval);
+  }
+}
+
+// Start initialization loop
+const loopInterval = setInterval(init, 1000);
+
+// Also try to initialize immediately if DOM is ready
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  init();
+}

--- a/src/content_scripts/jira.js
+++ b/src/content_scripts/jira.js
@@ -746,3 +746,32 @@ const loopInterval = setInterval(init, 1000);
 if (document.readyState === 'complete' || document.readyState === 'interactive') {
   init();
 }
+
+/**
+ * Message listener for popup context requests
+ */
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.message === 'getPageContext') {
+    // Gather context from the current page for smart autocomplete
+    const metadata = getJiraMetadata();
+
+    if (metadata) {
+      sendResponse({
+        context: {
+          type: 'jira-issue',
+          platform: 'jira',
+          issueKey: metadata.issueKey,
+          summary: metadata.summary,
+          title: metadata.summary,
+          description: metadata.description,
+          issueType: metadata.issueType,
+          priority: metadata.priority,
+          url: metadata.issueUrl,
+        },
+      });
+    } else {
+      sendResponse({ context: null });
+    }
+    return true;
+  }
+});

--- a/src/content_scripts/slack.js
+++ b/src/content_scripts/slack.js
@@ -102,14 +102,16 @@ marvinSuccessMessage.classList.add(
 );
 
 function showSuccessMessage(status) {
-  marvinSuccessMessage.textContent =
-    status === "success"
-      ? "Task successfully added to Marvin!"
-      : "Failed to add Task to Marvin!";
-
-  if (status === "noToken") {
-    marvinSuccessMessage.textContent +=
-      " Please add your Marvin API token in the extension settings.";
+  if (status === "success") {
+    marvinSuccessMessage.textContent = "Task successfully added to Marvin!";
+  } else if (status === "noToken") {
+    marvinSuccessMessage.textContent =
+      "Failed to add Task to Marvin! Please add your Marvin API token in the extension settings.";
+  } else if (status === "reload") {
+    marvinSuccessMessage.textContent =
+      "Extension was updated. Please reload this page to continue using Marvin.";
+  } else {
+    marvinSuccessMessage.textContent = "Failed to add Task to Marvin!";
   }
 
   marvinSuccessMessage.classList.remove("marvinSuccessMessageHidden");
@@ -119,7 +121,7 @@ function showSuccessMessage(status) {
       marvinSuccessMessage.classList.remove("marvinSuccessMessageVisible");
       marvinSuccessMessage.classList.add("marvinSuccessMessageHidden");
     },
-    status === "noToken" ? 6000 : 2000
+    status === "noToken" || status === "reload" ? 6000 : 2000
   );
 }
 
@@ -273,10 +275,38 @@ function getSlackMessageMetadata(messageElement) {
 let scheduleForToday = true;
 
 /**
+ * Checks if extension context is still valid
+ */
+function isExtensionContextValid() {
+  try {
+    // This will throw if context is invalidated
+    chrome.runtime.getURL("");
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * Handles click on Marvin button
  */
 async function handleMarvinButtonClick(metadata) {
-  const token = await getStoredToken();
+  // Check if extension context is still valid
+  if (!isExtensionContextValid()) {
+    showSuccessMessage("reload");
+    return;
+  }
+
+  let token;
+  try {
+    token = await getStoredToken();
+  } catch (error) {
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+      return;
+    }
+    throw error;
+  }
 
   if (!token) {
     showSuccessMessage("noToken");
@@ -338,7 +368,11 @@ async function handleMarvinButtonClick(metadata) {
     showSuccessMessage(result);
   } catch (error) {
     console.error("Failed to add task to Marvin:", error);
-    showSuccessMessage("fail");
+    if (error.message?.includes("Extension context invalidated")) {
+      showSuccessMessage("reload");
+    } else {
+      showSuccessMessage("fail");
+    }
   }
 }
 

--- a/src/content_scripts/slack.js
+++ b/src/content_scripts/slack.js
@@ -336,8 +336,8 @@ function createMarvinButton(metadata) {
   // Use Slack's native button classes for consistent styling
   button.className = "c-button-unstyled c-icon_button c-icon_button--size_small c-message_actions__button c-icon_button--default marvinButton";
   button.setAttribute("aria-label", "Add to Marvin");
+  button.setAttribute("title", "Add to Marvin");
   button.setAttribute("data-qa", "add_to_marvin");
-  button.setAttribute("data-sk", "tooltip_parent");
   button.setAttribute("type", "button");
 
   // Create img element with Marvin logo, sized to match Slack's icons

--- a/src/content_scripts/slack.js
+++ b/src/content_scripts/slack.js
@@ -1,0 +1,630 @@
+import { getStoredSlackSettings, getStoredToken } from "../utils/storage";
+import { addTask } from "../utils/api";
+import { formatDate } from "../utils/dates";
+
+const logo = chrome.runtime.getURL("static/logo.png");
+
+// Slack-specific selectors (Slack's DOM changes frequently, multiple fallbacks)
+const SELECTORS = {
+  // Virtual list containers
+  virtualList: '[data-qa="virtual-list"]',
+  virtualListItem: '[data-qa="virtual-list-item"]',
+
+  // Message containers
+  messageContainer: '[data-qa="message-container"]',
+  messageKit: '.c-message_kit__message',
+  messageListContainer: '.c-message_list',
+  messageListItem: '.c-message_list__item',
+
+  // Message actions toolbar (appears on hover)
+  messageActions: '.c-message_actions__container',
+  messageActionsGroup: '.c-message_actions__group',
+  hoverMenu: '[data-qa="message_actions"]',
+
+  // Message content elements
+  messageBody: '.c-message_kit__text',
+  richText: '.p-rich_text_section',
+  messageContent: '.c-message__content',
+  messageText: '.c-message_kit__blocks',
+
+  // Metadata elements
+  messageSender: '.c-message__sender',
+  senderLink: '.c-message__sender_link',
+  senderButton: '[data-qa="message_sender_name"]',
+  timestamp: '.c-timestamp',
+  timestampLabel: '.c-timestamp__label',
+  timestampLink: '[data-qa="timestamp"]',
+
+  // Context elements
+  channelHeader: '.p-view_header__channel_title',
+  channelHeaderButton: '[data-qa="channel_name"]',
+  channelName: '[data-qa="channel-header-label"]',
+  conversationHeader: '.p-conversation_header__title',
+  workspaceSwitcher: '[data-qa="team-menu-trigger"]',
+
+  // Thread elements
+  threadView: '.p-flexpane',
+  threadContainer: '[data-qa="thread-message-list"]',
+  threadParent: '[data-qa="thread_parent_message"]',
+
+  // Unreads view
+  unreadsContainer: '[data-qa="unreads_view"]',
+  activityItem: '.p-activity_bar_item',
+};
+
+/*
+    ***************
+    Success Message
+    ***************
+*/
+
+const marvinSuccessMessage = document.createElement("div");
+document.body.appendChild(marvinSuccessMessage);
+
+let marvinSuccessStyles = document.createElement("style");
+marvinSuccessStyles.appendChild(
+  document.createTextNode(`
+    .marvinSuccessMessageVisible {
+        display: grid;
+        place-items: center;
+    }
+
+    .marvinSuccessMessageHidden {
+        display: none;
+    }
+
+    .marvinSuccessMessage {
+        background: linear-gradient(165deg, #26d6c4 0%, #10b1d3 100%);
+        box-shadow: 0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a;
+        color: white;
+        font-size: 18px;
+        position: fixed !important;
+        bottom: 5%;
+        left: 50%;
+        transform: translate(-50%, 0);
+        width: 350px;
+        height: 75px;
+        z-index: 9999;
+        border-radius: 10px;
+        text-align: center;
+        padding: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }`)
+);
+document.getElementsByTagName("head")[0].appendChild(marvinSuccessStyles);
+
+marvinSuccessMessage.classList.add(
+  "marvinSuccessMessage",
+  "marvinSuccessMessageHidden"
+);
+
+function showSuccessMessage(status) {
+  marvinSuccessMessage.textContent =
+    status === "success"
+      ? "Task successfully added to Marvin!"
+      : "Failed to add Task to Marvin!";
+
+  if (status === "noToken") {
+    marvinSuccessMessage.textContent +=
+      " Please add your Marvin API token in the extension settings.";
+  }
+
+  marvinSuccessMessage.classList.remove("marvinSuccessMessageHidden");
+  marvinSuccessMessage.classList.add("marvinSuccessMessageVisible");
+  setTimeout(
+    () => {
+      marvinSuccessMessage.classList.remove("marvinSuccessMessageVisible");
+      marvinSuccessMessage.classList.add("marvinSuccessMessageHidden");
+    },
+    status === "noToken" ? 6000 : 2000
+  );
+}
+
+/*
+    ***************
+    Metadata Extraction
+    ***************
+*/
+
+/**
+ * Gets the current channel or conversation name
+ */
+function getChannelName() {
+  // Try multiple selectors as Slack's DOM varies
+  const channelHeader =
+    document.querySelector(SELECTORS.channelHeader) ||
+    document.querySelector(SELECTORS.channelHeaderButton) ||
+    document.querySelector(SELECTORS.channelName) ||
+    document.querySelector(SELECTORS.conversationHeader);
+
+  if (channelHeader) {
+    return channelHeader.textContent.trim();
+  }
+
+  // Fallback: extract from URL if possible
+  // URL format: https://app.slack.com/client/{workspace}/{channel}
+  const urlParts = window.location.pathname.split("/");
+  if (urlParts.length >= 4) {
+    return urlParts[3]; // Channel ID
+  }
+
+  return "Slack";
+}
+
+/**
+ * Gets sender name from a message element
+ */
+function getSenderName(messageElement) {
+  const senderElement =
+    messageElement.querySelector(SELECTORS.senderLink) ||
+    messageElement.querySelector(SELECTORS.senderButton) ||
+    messageElement.querySelector(SELECTORS.messageSender);
+
+  if (senderElement) {
+    return senderElement.textContent.trim();
+  }
+
+  // Try aria-label on avatar
+  const avatar = messageElement.querySelector(".c-avatar");
+  if (avatar) {
+    const ariaLabel = avatar.getAttribute("aria-label");
+    if (ariaLabel) return ariaLabel;
+  }
+
+  return "Unknown";
+}
+
+/**
+ * Gets message text content
+ */
+function getMessageText(messageElement) {
+  const textElement =
+    messageElement.querySelector(SELECTORS.richText) ||
+    messageElement.querySelector(SELECTORS.messageBody) ||
+    messageElement.querySelector(SELECTORS.messageContent) ||
+    messageElement.querySelector(SELECTORS.messageText);
+
+  if (textElement) {
+    return textElement.textContent.trim();
+  }
+
+  return "";
+}
+
+/**
+ * Gets timestamp from a message element
+ */
+function getTimestamp(messageElement) {
+  const timestampElement =
+    messageElement.querySelector(SELECTORS.timestampLink) ||
+    messageElement.querySelector(SELECTORS.timestamp);
+
+  if (timestampElement) {
+    // Try aria-label first (usually has full date/time)
+    const ariaLabel = timestampElement.getAttribute("aria-label");
+    if (ariaLabel) return ariaLabel;
+
+    // Try the label inside
+    const labelElement = timestampElement.querySelector(SELECTORS.timestampLabel);
+    if (labelElement) return labelElement.textContent.trim();
+
+    return timestampElement.textContent.trim();
+  }
+
+  return "";
+}
+
+/**
+ * Constructs a permalink for the message
+ */
+function constructPermalink(messageElement) {
+  // Try to get timestamp data attribute which Slack uses for permalinks
+  const timestampElement = messageElement.querySelector(SELECTORS.timestamp) ||
+                           messageElement.querySelector(SELECTORS.timestampLink);
+
+  if (timestampElement) {
+    // Check for href which is often the permalink
+    const href = timestampElement.getAttribute("href");
+    if (href && href.startsWith("/archives/")) {
+      return `https://slack.com${href}`;
+    }
+  }
+
+  // Fallback to current URL
+  return window.location.href;
+}
+
+/**
+ * Determines if message is in a thread view
+ */
+function isInThread(messageElement) {
+  return !!messageElement.closest(SELECTORS.threadView) ||
+         !!messageElement.closest(SELECTORS.threadContainer);
+}
+
+/**
+ * Builds complete Slack message metadata
+ */
+function getSlackMessageMetadata(messageElement) {
+  const messageText = getMessageText(messageElement);
+
+  // Skip if no message text
+  if (!messageText) return null;
+
+  return {
+    senderName: getSenderName(messageElement),
+    channelName: getChannelName(),
+    messageText,
+    timestamp: getTimestamp(messageElement),
+    permalink: constructPermalink(messageElement),
+    isThread: isInThread(messageElement),
+  };
+}
+
+/*
+    ***************
+    Button Creation
+    ***************
+*/
+
+let scheduleForToday = true;
+
+/**
+ * Handles click on Marvin button
+ */
+async function handleMarvinButtonClick(metadata) {
+  const token = await getStoredToken();
+
+  if (!token) {
+    showSuccessMessage("noToken");
+    return;
+  }
+
+  // Format title: [Slack: Channel/DM] Message preview...
+  const titlePreview =
+    metadata.messageText.length > 60
+      ? metadata.messageText.substring(0, 57) + "..."
+      : metadata.messageText;
+
+  const data = {
+    title: `[Slack: ${metadata.channelName}] ${titlePreview}`,
+    done: false,
+  };
+
+  // Build note with message metadata
+  let noteLines = [":::info"];
+  noteLines.push(`From: ${metadata.senderName}`);
+  noteLines.push(`Channel: ${metadata.channelName}`);
+  if (metadata.timestamp) {
+    noteLines.push(`Time: ${metadata.timestamp}`);
+  }
+  if (metadata.isThread) {
+    noteLines.push("(Thread message)");
+  }
+  noteLines.push("");
+  noteLines.push("Message:");
+  noteLines.push(metadata.messageText);
+
+  if (metadata.permalink) {
+    noteLines.push("");
+    noteLines.push(`[View in Slack](${metadata.permalink})`);
+  }
+
+  data.note = noteLines.join("\n");
+
+  if (scheduleForToday) {
+    data.day = formatDate(new Date());
+  }
+
+  try {
+    const result = await addTask(data);
+    showSuccessMessage(result);
+  } catch (error) {
+    console.error("Failed to add task to Marvin:", error);
+    showSuccessMessage("fail");
+  }
+}
+
+/**
+ * Creates a Marvin button for Slack messages
+ */
+function createMarvinButton(metadata) {
+  const button = document.createElement("button");
+  button.classList.add("marvinButton");
+  button.setAttribute("aria-label", "Add to Marvin");
+  button.setAttribute("title", "Add to Marvin");
+  button.setAttribute("type", "button");
+
+  // Style to match Slack's action buttons
+  button.style.cssText = `
+    background: url(${logo}) no-repeat center center;
+    background-size: 16px 16px;
+    width: 28px;
+    height: 28px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.2s, background-color 0.1s;
+    flex-shrink: 0;
+    margin: 0 2px;
+  `;
+
+  button.onmouseenter = () => {
+    button.style.opacity = "1";
+    button.style.backgroundColor = "rgba(29, 28, 29, 0.04)";
+  };
+  button.onmouseleave = () => {
+    button.style.opacity = "0.7";
+    button.style.backgroundColor = "transparent";
+  };
+
+  button.onclick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleMarvinButtonClick(metadata);
+  };
+
+  return button;
+}
+
+/*
+    ***************
+    Button Injection
+    ***************
+*/
+
+/**
+ * Checks if Marvin button already exists in container
+ */
+function marvinButtonExists(container) {
+  return container.querySelector(".marvinButton") !== null;
+}
+
+/**
+ * Adds Marvin button to a message element
+ */
+function addButtonToMessage(messageElement) {
+  // Skip if button already exists
+  if (marvinButtonExists(messageElement)) return;
+
+  const metadata = getSlackMessageMetadata(messageElement);
+  if (!metadata) return; // Skip empty messages
+
+  // Check view settings
+  const isThread = metadata.isThread;
+  const channelName = metadata.channelName.toLowerCase();
+  const isDM = channelName.includes("direct message") || channelName.match(/^[a-z]+, [a-z]+/i);
+
+  if (isThread && !showInThreads) return;
+  if (isDM && !showInDMs) return;
+  if (!isThread && !isDM && !showInChannels) return;
+
+  const button = createMarvinButton(metadata);
+
+  // Strategy 1: Add to message actions toolbar (most reliable)
+  const actionsContainer = messageElement.querySelector(SELECTORS.messageActions);
+  if (actionsContainer) {
+    const actionsGroup = actionsContainer.querySelector(SELECTORS.messageActionsGroup);
+    if (actionsGroup) {
+      actionsGroup.appendChild(button);
+      return;
+    }
+    actionsContainer.appendChild(button);
+    return;
+  }
+
+  // Strategy 2: Add to hover menu
+  const hoverMenu = messageElement.querySelector(SELECTORS.hoverMenu);
+  if (hoverMenu) {
+    hoverMenu.appendChild(button);
+    return;
+  }
+
+  // Strategy 3: Create a hover container on the message itself
+  const messageKit =
+    messageElement.querySelector(SELECTORS.messageKit) || messageElement;
+
+  // Check if we already added a container
+  if (messageKit.querySelector(".marvin-button-container")) return;
+
+  const buttonContainer = document.createElement("div");
+  buttonContainer.classList.add("marvin-button-container");
+  buttonContainer.style.cssText = `
+    position: absolute;
+    right: 8px;
+    top: 4px;
+    opacity: 0;
+    transition: opacity 0.2s;
+    z-index: 100;
+    background: white;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+  `;
+  buttonContainer.appendChild(button);
+
+  // Make message position relative if not already
+  const computedStyle = window.getComputedStyle(messageKit);
+  if (computedStyle.position === "static") {
+    messageKit.style.position = "relative";
+  }
+
+  messageKit.appendChild(buttonContainer);
+
+  // Show on hover
+  const showButton = () => {
+    buttonContainer.style.opacity = "1";
+  };
+  const hideButton = () => {
+    buttonContainer.style.opacity = "0";
+  };
+
+  messageKit.addEventListener("mouseenter", showButton);
+  messageKit.addEventListener("mouseleave", hideButton);
+}
+
+/**
+ * Adds buttons to all visible messages
+ */
+function addButtonsToMessages() {
+  // Query for various message container types
+  const messageContainers = document.querySelectorAll(SELECTORS.messageContainer);
+  const messageKits = document.querySelectorAll(SELECTORS.messageKit);
+  const listItems = document.querySelectorAll(SELECTORS.messageListItem);
+  const virtualItems = document.querySelectorAll(SELECTORS.virtualListItem);
+
+  // Combine all message elements
+  const allMessages = [
+    ...Array.from(messageContainers),
+    ...Array.from(messageKits),
+    ...Array.from(listItems),
+    ...Array.from(virtualItems),
+  ];
+
+  // Filter unique elements and those that contain message content
+  const processedElements = new Set();
+  const uniqueMessages = allMessages.filter((el) => {
+    if (processedElements.has(el)) return false;
+    processedElements.add(el);
+
+    // Must have some message content
+    const hasContent =
+      el.querySelector(SELECTORS.richText) ||
+      el.querySelector(SELECTORS.messageBody) ||
+      el.querySelector(SELECTORS.messageText);
+    return hasContent;
+  });
+
+  uniqueMessages.forEach((message) => {
+    addButtonToMessage(message);
+  });
+
+  return uniqueMessages.length > 0;
+}
+
+/*
+    ***************
+    Main Logic
+    ***************
+*/
+
+let enabled = true;
+let showInChannels = true;
+let showInDMs = true;
+let showInThreads = true;
+let isInitialized = false;
+let observer = null;
+
+/**
+ * Debounce function
+ */
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+}
+
+const debouncedAddButtons = debounce(addButtonsToMessages, 250);
+
+/**
+ * Handles DOM mutations - watches for new messages
+ */
+function handleMutation(mutationsList) {
+  for (const mutation of mutationsList) {
+    if (mutation.type !== "childList" || mutation.addedNodes.length === 0)
+      continue;
+
+    for (const node of mutation.addedNodes) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+      // Check if this is or contains a message element
+      if (
+        node.matches?.(SELECTORS.messageContainer) ||
+        node.matches?.(SELECTORS.messageKit) ||
+        node.matches?.(SELECTORS.virtualListItem) ||
+        node.querySelector?.(SELECTORS.messageContainer) ||
+        node.querySelector?.(SELECTORS.messageKit) ||
+        node.querySelector?.(SELECTORS.richText)
+      ) {
+        debouncedAddButtons();
+        return;
+      }
+
+      // Check for message actions appearing (on hover)
+      if (
+        node.matches?.(SELECTORS.messageActions) ||
+        node.querySelector?.(SELECTORS.messageActions)
+      ) {
+        debouncedAddButtons();
+        return;
+      }
+    }
+  }
+}
+
+/**
+ * Checks if Slack has loaded
+ */
+function isSlackLoaded() {
+  return (
+    document.querySelector(SELECTORS.virtualList) ||
+    document.querySelector(SELECTORS.messageListContainer) ||
+    document.querySelector('[data-qa="message_list"]') ||
+    document.querySelector('[data-qa="slack_kit_list"]')
+  );
+}
+
+/**
+ * Initializes the content script
+ */
+async function init() {
+  // Load settings
+  const settings = await getStoredSlackSettings();
+  enabled = settings.enabled ?? true;
+  scheduleForToday = settings.scheduleForToday ?? true;
+  showInChannels = settings.showInChannels ?? true;
+  showInDMs = settings.showInDMs ?? true;
+  showInThreads = settings.showInThreads ?? true;
+
+  // If disabled, don't proceed
+  if (!enabled) {
+    clearInterval(loopInterval);
+    return;
+  }
+
+  // Wait for Slack to load
+  if (!isSlackLoaded() && !isInitialized) {
+    return;
+  }
+
+  // Add buttons to current messages
+  addButtonsToMessages();
+
+  if (!isInitialized) {
+    isInitialized = true;
+
+    // Set up MutationObserver for dynamic content
+    observer = new MutationObserver(handleMutation);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Stop the initial interval
+    clearInterval(loopInterval);
+
+    console.log("Marvin Slack integration initialized");
+  }
+}
+
+// Start initialization loop
+const loopInterval = setInterval(init, 1000);
+
+// Also try to initialize immediately if DOM is ready
+if (document.readyState === "complete" || document.readyState === "interactive") {
+  init();
+}

--- a/src/content_scripts/slack.js
+++ b/src/content_scripts/slack.js
@@ -2,6 +2,8 @@ import { getStoredSlackSettings, getStoredToken } from "../utils/storage";
 import { addTask } from "../utils/api";
 import { formatDate } from "../utils/dates";
 
+const logo = chrome.runtime.getURL("static/logo.png");
+
 // Slack-specific selectors (Slack's DOM changes frequently, multiple fallbacks)
 const SELECTORS = {
   // Virtual list containers
@@ -338,13 +340,14 @@ function createMarvinButton(metadata) {
   button.setAttribute("data-sk", "tooltip_parent");
   button.setAttribute("type", "button");
 
-  // Create SVG icon matching Slack's style (checkmark/task icon)
-  // Using Slack's viewBox="0 0 20 20" standard
-  button.innerHTML = `
-    <svg data-qa="marvin-icon" aria-hidden="true" viewBox="0 0 20 20" class="">
-      <path fill="currentColor" fill-rule="evenodd" d="M10 2a8 8 0 1 0 0 16 8 8 0 0 0 0-16m3.78 5.97a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0l-2.25-2.25a.75.75 0 1 1 1.06-1.06l1.72 1.72 3.72-3.72a.75.75 0 0 1 1.06 0" clip-rule="evenodd"></path>
-    </svg>
-  `;
+  // Create img element with Marvin logo, sized to match Slack's icons
+  const img = document.createElement("img");
+  img.src = logo;
+  img.alt = "Add to Marvin";
+  img.setAttribute("aria-hidden", "true");
+  img.style.cssText = "width: 18px; height: 18px; display: block;";
+
+  button.appendChild(img);
 
   button.onclick = (e) => {
     e.preventDefault();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,6 +36,15 @@
     },
     {
       "matches": [
+        "*://app.slack.com/*",
+        "*://*.slack.com/*"
+      ],
+      "js": [
+        "./content_scripts/slack.js"
+      ]
+    },
+    {
+      "matches": [
         "<all_urls>"
       ],
       "js": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -85,7 +85,8 @@
     }
   ],
   "host_permissions": [
-    "https://serv.amazingmarvin.com/api/*"
+    "https://serv.amazingmarvin.com/api/*",
+    "https://api.anthropic.com/*"
   ],
   "permissions": [
     "storage",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,6 +45,18 @@
     },
     {
       "matches": [
+        "*://github.com/*/*/pull/*",
+        "*://github.com/pulls",
+        "*://github.com/pulls/*",
+        "*://github.com/*/*/pulls",
+        "*://github.com/*/*/pulls/*"
+      ],
+      "js": [
+        "./content_scripts/github-pr.js"
+      ]
+    },
+    {
+      "matches": [
         "<all_urls>"
       ],
       "js": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -86,7 +86,9 @@
   ],
   "host_permissions": [
     "https://serv.amazingmarvin.com/api/*",
-    "https://api.anthropic.com/*"
+    "https://api.anthropic.com/*",
+    "https://api.openai.com/*",
+    "https://generativelanguage.googleapis.com/*"
   ],
   "permissions": [
     "storage",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -49,7 +49,10 @@
         "*://github.com/pulls",
         "*://github.com/pulls/*",
         "*://github.com/*/*/pulls",
-        "*://github.com/*/*/pulls/*"
+        "*://github.com/*/*/pulls/*",
+        "*://github.com/*/*/issues/*",
+        "*://github.com/notifications",
+        "*://github.com/notifications/*"
       ],
       "js": [
         "./content_scripts/github-pr.js"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,14 @@
     },
     {
       "matches": [
+        "*://*.atlassian.net/*"
+      ],
+      "js": [
+        "./content_scripts/jira.js"
+      ]
+    },
+    {
+      "matches": [
         "<all_urls>"
       ],
       "js": [

--- a/src/options/App.js
+++ b/src/options/App.js
@@ -12,6 +12,7 @@ const App = () => {
     { name: "api", text: "API Token" },
     { name: "sync", text: "Sync" },
     { name: "gmail", text: "Gmail Addon" },
+    { name: "jira", text: "Jira Addon" },
   ];
 
   return (

--- a/src/options/App.js
+++ b/src/options/App.js
@@ -12,6 +12,7 @@ const App = () => {
     { name: "api", text: "API Token" },
     { name: "sync", text: "Sync" },
     { name: "smartAutocomplete", text: "Smart Autocomplete" },
+    { name: "aiSuggestions", text: "AI Suggestions" },
     { name: "gmail", text: "Gmail Addon" },
     { name: "jira", text: "Jira Addon" },
     { name: "slack", text: "Slack Addon" },

--- a/src/options/App.js
+++ b/src/options/App.js
@@ -14,6 +14,7 @@ const App = () => {
     { name: "gmail", text: "Gmail Addon" },
     { name: "jira", text: "Jira Addon" },
     { name: "slack", text: "Slack Addon" },
+    { name: "github", text: "GitHub Addon" },
   ];
 
   return (

--- a/src/options/App.js
+++ b/src/options/App.js
@@ -13,6 +13,7 @@ const App = () => {
     { name: "sync", text: "Sync" },
     { name: "gmail", text: "Gmail Addon" },
     { name: "jira", text: "Jira Addon" },
+    { name: "slack", text: "Slack Addon" },
   ];
 
   return (

--- a/src/options/App.js
+++ b/src/options/App.js
@@ -11,6 +11,7 @@ const App = () => {
     { name: "badge", text: "Badge" },
     { name: "api", text: "API Token" },
     { name: "sync", text: "Sync" },
+    { name: "smartAutocomplete", text: "Smart Autocomplete" },
     { name: "gmail", text: "Gmail Addon" },
     { name: "jira", text: "Jira Addon" },
     { name: "slack", text: "Slack Addon" },

--- a/src/options/components/OptionsContent.js
+++ b/src/options/components/OptionsContent.js
@@ -3,6 +3,7 @@ import OptionsContentBadge from "./OptionsContentBadge";
 import OptionsContentApi from "./OptionsContentApi";
 import OptionsContentSync from "./OptionsContentSync";
 import OptionsContentGmail from "./OptionsContentGmail";
+import OptionsContentJira from "./OptionsContentJira";
 
 const OptionsContent = ({ selectedSetting }) => {
   switch (selectedSetting) {
@@ -16,6 +17,8 @@ const OptionsContent = ({ selectedSetting }) => {
       return <OptionsContentSync />;
     case "gmail":
       return <OptionsContentGmail />;
+    case "jira":
+      return <OptionsContentJira />;
     default:
       return <OptionsContentGeneral />;
   }

--- a/src/options/components/OptionsContent.js
+++ b/src/options/components/OptionsContent.js
@@ -6,6 +6,7 @@ import OptionsContentGmail from "./OptionsContentGmail";
 import OptionsContentJira from "./OptionsContentJira";
 import OptionsContentSlack from "./OptionsContentSlack";
 import OptionsContentGitHub from "./OptionsContentGitHub";
+import OptionsContentSmartAutocomplete from "./OptionsContentSmartAutocomplete";
 
 const OptionsContent = ({ selectedSetting }) => {
   switch (selectedSetting) {
@@ -17,6 +18,8 @@ const OptionsContent = ({ selectedSetting }) => {
       return <OptionsContentApi />;
     case "sync":
       return <OptionsContentSync />;
+    case "smartAutocomplete":
+      return <OptionsContentSmartAutocomplete />;
     case "gmail":
       return <OptionsContentGmail />;
     case "jira":

--- a/src/options/components/OptionsContent.js
+++ b/src/options/components/OptionsContent.js
@@ -7,6 +7,7 @@ import OptionsContentJira from "./OptionsContentJira";
 import OptionsContentSlack from "./OptionsContentSlack";
 import OptionsContentGitHub from "./OptionsContentGitHub";
 import OptionsContentSmartAutocomplete from "./OptionsContentSmartAutocomplete";
+import OptionsContentAI from "./OptionsContentAI";
 
 const OptionsContent = ({ selectedSetting }) => {
   switch (selectedSetting) {
@@ -20,6 +21,8 @@ const OptionsContent = ({ selectedSetting }) => {
       return <OptionsContentSync />;
     case "smartAutocomplete":
       return <OptionsContentSmartAutocomplete />;
+    case "aiSuggestions":
+      return <OptionsContentAI />;
     case "gmail":
       return <OptionsContentGmail />;
     case "jira":

--- a/src/options/components/OptionsContent.js
+++ b/src/options/components/OptionsContent.js
@@ -4,6 +4,7 @@ import OptionsContentApi from "./OptionsContentApi";
 import OptionsContentSync from "./OptionsContentSync";
 import OptionsContentGmail from "./OptionsContentGmail";
 import OptionsContentJira from "./OptionsContentJira";
+import OptionsContentSlack from "./OptionsContentSlack";
 
 const OptionsContent = ({ selectedSetting }) => {
   switch (selectedSetting) {
@@ -19,6 +20,8 @@ const OptionsContent = ({ selectedSetting }) => {
       return <OptionsContentGmail />;
     case "jira":
       return <OptionsContentJira />;
+    case "slack":
+      return <OptionsContentSlack />;
     default:
       return <OptionsContentGeneral />;
   }

--- a/src/options/components/OptionsContent.js
+++ b/src/options/components/OptionsContent.js
@@ -5,6 +5,7 @@ import OptionsContentSync from "./OptionsContentSync";
 import OptionsContentGmail from "./OptionsContentGmail";
 import OptionsContentJira from "./OptionsContentJira";
 import OptionsContentSlack from "./OptionsContentSlack";
+import OptionsContentGitHub from "./OptionsContentGitHub";
 
 const OptionsContent = ({ selectedSetting }) => {
   switch (selectedSetting) {
@@ -22,6 +23,8 @@ const OptionsContent = ({ selectedSetting }) => {
       return <OptionsContentJira />;
     case "slack":
       return <OptionsContentSlack />;
+    case "github":
+      return <OptionsContentGitHub />;
     default:
       return <OptionsContentGeneral />;
   }

--- a/src/options/components/OptionsContentAI.js
+++ b/src/options/components/OptionsContentAI.js
@@ -1,0 +1,232 @@
+import { useEffect, useState } from "react";
+import { BsEye, BsEyeSlash, BsCheckCircle, BsXCircle } from "react-icons/bs";
+
+import {
+  getStoredAISuggestionsSettings,
+  setStoredAISuggestionsSettings,
+} from "../../utils/storage";
+import { verifyAnthropicApiKey } from "../../utils/ai";
+
+const OptionsContentAI = () => {
+  const [enabled, setEnabled] = useState(false);
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [showTokenUsage, setShowTokenUsage] = useState(false);
+  const [cacheEnabled, setCacheEnabled] = useState(true);
+
+  const [verifying, setVerifying] = useState(false);
+  const [verificationStatus, setVerificationStatus] = useState(null);
+  const [saveMessage, setSaveMessage] = useState('');
+
+  useEffect(() => {
+    getStoredAISuggestionsSettings().then((settings) => {
+      if (settings) {
+        setEnabled(settings.enabled ?? false);
+        setApiKey(settings.apiKey ?? '');
+        setShowTokenUsage(settings.showTokenUsage ?? false);
+        setCacheEnabled(settings.cacheEnabled ?? true);
+      }
+    });
+  }, []);
+
+  const getAllSettings = () => ({
+    enabled,
+    apiKey,
+    showTokenUsage,
+    cacheEnabled,
+    cacheTTL: 3600000,
+  });
+
+  const saveSettings = (newSettings) => {
+    setStoredAISuggestionsSettings(newSettings);
+    setSaveMessage('Settings saved!');
+    setTimeout(() => setSaveMessage(''), 2000);
+  };
+
+  const handleVerifyApiKey = async () => {
+    if (!apiKey) return;
+
+    setVerifying(true);
+    setVerificationStatus(null);
+
+    const isValid = await verifyAnthropicApiKey(apiKey);
+    setVerificationStatus(isValid ? 'valid' : 'invalid');
+    setVerifying(false);
+  };
+
+  const handleSaveApiKey = () => {
+    saveSettings({ ...getAllSettings(), apiKey });
+  };
+
+  const handleEnabledChange = () => {
+    const newValue = !enabled;
+    setEnabled(newValue);
+    saveSettings({ ...getAllSettings(), enabled: newValue });
+  };
+
+  const handleShowTokenUsageChange = () => {
+    const newValue = !showTokenUsage;
+    setShowTokenUsage(newValue);
+    saveSettings({ ...getAllSettings(), showTokenUsage: newValue });
+  };
+
+  const handleCacheEnabledChange = () => {
+    const newValue = !cacheEnabled;
+    setCacheEnabled(newValue);
+    saveSettings({ ...getAllSettings(), cacheEnabled: newValue });
+  };
+
+  return (
+    <>
+      {/* Enable AI Suggestions */}
+      <div className="rounded-lg bg-white shadow-lg text-sm">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Enable AI Suggestions</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Use Claude AI (Haiku model) to generate intelligent task suggestions
+              based on the source content. This provides smarter titles, time estimates,
+              and label suggestions than the template-based autocomplete.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={handleEnabledChange}
+                disabled={!apiKey}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+          {!apiKey && (
+            <p className="text-sm text-amber-600">
+              Add your Anthropic API key below to enable AI suggestions.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* API Key */}
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Anthropic API Key</h3>
+          <p className="mb-4 text-gray-600">
+            Enter your Anthropic API key to enable AI-powered suggestions.
+            Get your API key from{" "}
+            <a
+              href="https://console.anthropic.com/settings/keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[#1CC5CB] hover:underline"
+            >
+              console.anthropic.com
+            </a>
+            . Your key is stored locally and never shared.
+          </p>
+          <div className="flex flex-row gap-2">
+            <div className="relative flex-1">
+              <input
+                type={showApiKey ? "text" : "password"}
+                value={apiKey}
+                onChange={(e) => {
+                  setApiKey(e.target.value);
+                  setVerificationStatus(null);
+                }}
+                placeholder="sk-ant-api..."
+                className="w-full px-3 py-2 pr-10 border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-[#1CC5CB]"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+              >
+                {showApiKey ? <BsEyeSlash size={18} /> : <BsEye size={18} />}
+              </button>
+            </div>
+            <button
+              onClick={handleVerifyApiKey}
+              disabled={!apiKey || verifying}
+              className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg disabled:opacity-50"
+            >
+              {verifying ? "Verifying..." : "Verify"}
+            </button>
+            <button
+              onClick={handleSaveApiKey}
+              disabled={!apiKey}
+              className="px-4 py-2 bg-[#1CC5CB] text-white hover:bg-[#18b0b5] rounded-lg disabled:opacity-50"
+            >
+              Save
+            </button>
+          </div>
+          {verificationStatus && (
+            <div className={`mt-2 flex items-center gap-2 ${verificationStatus === 'valid' ? 'text-green-600' : 'text-red-600'}`}>
+              {verificationStatus === 'valid' ? (
+                <><BsCheckCircle /> API key is valid</>
+              ) : (
+                <><BsXCircle /> API key is invalid</>
+              )}
+            </div>
+          )}
+          {saveMessage && (
+            <div className="mt-2 text-green-600">{saveMessage}</div>
+          )}
+        </div>
+      </div>
+
+      {/* Response Caching */}
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Response Caching</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Cache AI responses to reduce API calls and costs. Cached suggestions
+              are reused when you create tasks from the same source within an hour.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={cacheEnabled}
+                onChange={handleCacheEnabledChange}
+                disabled={!enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      {/* Token Usage Display */}
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Cost Information</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <div>
+              <p>
+                Show token usage information when AI generates suggestions.
+              </p>
+              <p className="text-gray-500 text-xs mt-1">
+                Claude Haiku costs approximately $0.00025 per 1K input tokens and
+                $0.00125 per 1K output tokens. A typical suggestion uses ~500 input
+                and ~100 output tokens (~$0.0003 per suggestion).
+              </p>
+            </div>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showTokenUsage}
+                onChange={handleShowTokenUsageChange}
+                disabled={!enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OptionsContentAI;

--- a/src/options/components/OptionsContentGitHub.js
+++ b/src/options/components/OptionsContentGitHub.js
@@ -11,6 +11,9 @@ const OptionsContentGitHub = () => {
   const [displayInPRView, setDisplayInPRView] = useState(true);
   const [displayInPRList, setDisplayInPRList] = useState(true);
   const [useSmartTitles, setUseSmartTitles] = useState(true);
+  const [displayInComments, setDisplayInComments] = useState(true);
+  const [displayInReviewComments, setDisplayInReviewComments] = useState(true);
+  const [displayInNotifications, setDisplayInNotifications] = useState(true);
 
   useEffect(() => {
     getStoredGitHubSettings().then((settings) => {
@@ -20,6 +23,9 @@ const OptionsContentGitHub = () => {
         setDisplayInPRView(settings.displayInPRView ?? true);
         setDisplayInPRList(settings.displayInPRList ?? true);
         setUseSmartTitles(settings.useSmartTitles ?? true);
+        setDisplayInComments(settings.displayInComments ?? true);
+        setDisplayInReviewComments(settings.displayInReviewComments ?? true);
+        setDisplayInNotifications(settings.displayInNotifications ?? true);
       }
     });
   }, []);
@@ -28,64 +34,63 @@ const OptionsContentGitHub = () => {
     setStoredGitHubSettings(newSettings);
   };
 
+  const getAllSettings = () => ({
+    enabled,
+    scheduleForToday,
+    displayInPRView,
+    displayInPRList,
+    useSmartTitles,
+    displayInComments,
+    displayInReviewComments,
+    displayInNotifications,
+  });
+
   const handleEnabledChange = () => {
     const newValue = !enabled;
     setEnabled(newValue);
-    saveSettings({
-      enabled: newValue,
-      scheduleForToday,
-      displayInPRView,
-      displayInPRList,
-      useSmartTitles,
-    });
+    saveSettings({ ...getAllSettings(), enabled: newValue });
   };
 
   const handleScheduleForTodayChange = () => {
     const newValue = !scheduleForToday;
     setScheduleForToday(newValue);
-    saveSettings({
-      enabled,
-      scheduleForToday: newValue,
-      displayInPRView,
-      displayInPRList,
-      useSmartTitles,
-    });
+    saveSettings({ ...getAllSettings(), scheduleForToday: newValue });
   };
 
   const handleDisplayInPRViewChange = () => {
     const newValue = !displayInPRView;
     setDisplayInPRView(newValue);
-    saveSettings({
-      enabled,
-      scheduleForToday,
-      displayInPRView: newValue,
-      displayInPRList,
-      useSmartTitles,
-    });
+    saveSettings({ ...getAllSettings(), displayInPRView: newValue });
   };
 
   const handleDisplayInPRListChange = () => {
     const newValue = !displayInPRList;
     setDisplayInPRList(newValue);
-    saveSettings({
-      enabled,
-      scheduleForToday,
-      displayInPRView,
-      displayInPRList: newValue,
-      useSmartTitles,
-    });
+    saveSettings({ ...getAllSettings(), displayInPRList: newValue });
   };
 
   const handleUseSmartTitlesChange = () => {
     const newValue = !useSmartTitles;
     setUseSmartTitles(newValue);
-    saveSettings({
-      enabled,
-      scheduleForToday,
-      displayInPRView,
-      displayInPRList,
-      useSmartTitles: newValue,
-    });
+    saveSettings({ ...getAllSettings(), useSmartTitles: newValue });
+  };
+
+  const handleDisplayInCommentsChange = () => {
+    const newValue = !displayInComments;
+    setDisplayInComments(newValue);
+    saveSettings({ ...getAllSettings(), displayInComments: newValue });
+  };
+
+  const handleDisplayInReviewCommentsChange = () => {
+    const newValue = !displayInReviewComments;
+    setDisplayInReviewComments(newValue);
+    saveSettings({ ...getAllSettings(), displayInReviewComments: newValue });
+  };
+
+  const handleDisplayInNotificationsChange = () => {
+    const newValue = !displayInNotifications;
+    setDisplayInNotifications(newValue);
+    saveSettings({ ...getAllSettings(), displayInNotifications: newValue });
   };
 
   return (
@@ -176,7 +181,7 @@ const OptionsContentGitHub = () => {
         </div>
       </div>
 
-      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
         <div className="px-6 py-8">
           <h3 className="font-bold mb-3">Use Smart Titles</h3>
           <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
@@ -191,6 +196,71 @@ const OptionsContentGitHub = () => {
                 type="checkbox"
                 checked={useSmartTitles}
                 onChange={handleUseSmartTitlesChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display in Comments</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button on PR and issue discussion
+              comments. Creates tasks like "Reply to @author on PR #123".
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInComments}
+                onChange={handleDisplayInCommentsChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display in Review Comments</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button on inline code review comments
+              in PR diff views. Creates tasks like "Address review comment on PR #123"
+              or "Apply suggestion on PR #123" for comments with code suggestions.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInReviewComments}
+                onChange={handleDisplayInReviewCommentsChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display in Notifications</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button on each notification row at
+              github.com/notifications. Creates context-aware tasks based on
+              notification type (review requests, mentions, assignments, etc.).
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInNotifications}
+                onChange={handleDisplayInNotificationsChange}
                 className="sr-only peer"
               />
               <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>

--- a/src/options/components/OptionsContentGitHub.js
+++ b/src/options/components/OptionsContentGitHub.js
@@ -1,0 +1,205 @@
+import { useEffect, useState } from "react";
+
+import {
+  getStoredGitHubSettings,
+  setStoredGitHubSettings,
+} from "../../utils/storage";
+
+const OptionsContentGitHub = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [scheduleForToday, setScheduleForToday] = useState(true);
+  const [displayInPRView, setDisplayInPRView] = useState(true);
+  const [displayInPRList, setDisplayInPRList] = useState(true);
+  const [useSmartTitles, setUseSmartTitles] = useState(true);
+
+  useEffect(() => {
+    getStoredGitHubSettings().then((settings) => {
+      if (settings) {
+        setEnabled(settings.enabled ?? true);
+        setScheduleForToday(settings.scheduleForToday ?? true);
+        setDisplayInPRView(settings.displayInPRView ?? true);
+        setDisplayInPRList(settings.displayInPRList ?? true);
+        setUseSmartTitles(settings.useSmartTitles ?? true);
+      }
+    });
+  }, []);
+
+  const saveSettings = (newSettings) => {
+    setStoredGitHubSettings(newSettings);
+  };
+
+  const handleEnabledChange = () => {
+    const newValue = !enabled;
+    setEnabled(newValue);
+    saveSettings({
+      enabled: newValue,
+      scheduleForToday,
+      displayInPRView,
+      displayInPRList,
+      useSmartTitles,
+    });
+  };
+
+  const handleScheduleForTodayChange = () => {
+    const newValue = !scheduleForToday;
+    setScheduleForToday(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday: newValue,
+      displayInPRView,
+      displayInPRList,
+      useSmartTitles,
+    });
+  };
+
+  const handleDisplayInPRViewChange = () => {
+    const newValue = !displayInPRView;
+    setDisplayInPRView(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday,
+      displayInPRView: newValue,
+      displayInPRList,
+      useSmartTitles,
+    });
+  };
+
+  const handleDisplayInPRListChange = () => {
+    const newValue = !displayInPRList;
+    setDisplayInPRList(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday,
+      displayInPRView,
+      displayInPRList: newValue,
+      useSmartTitles,
+    });
+  };
+
+  const handleUseSmartTitlesChange = () => {
+    const newValue = !useSmartTitles;
+    setUseSmartTitles(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday,
+      displayInPRView,
+      displayInPRList,
+      useSmartTitles: newValue,
+    });
+  };
+
+  return (
+    <>
+      <div className="rounded-lg bg-white shadow-lg text-sm">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Enable GitHub Integration</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When enabled, "Add to Marvin" buttons will appear on GitHub pull
+              request pages allowing you to quickly create tasks from PRs.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={handleEnabledChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Automatically schedule for Today</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When this setting is enabled, GitHub PRs sent to Marvin as tasks
+              will automatically get scheduled for today.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={scheduleForToday}
+                onChange={handleScheduleForTodayChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display in PR Detail View</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button when viewing individual pull
+              requests. The button appears in the PR header area next to other
+              actions.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInPRView}
+                onChange={handleDisplayInPRViewChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display in PR List View</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button in pull request list views
+              (github.com/pulls and repository PR lists). The button appears
+              next to each PR title.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInPRList}
+                onChange={handleDisplayInPRListChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Use Smart Titles</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Generate context-aware task titles based on PR state. For example:
+              "Review PR #123" for PRs needing review, "Fix pipeline for PR
+              #123" for your PRs with failing checks, or "Merge PR #123" for
+              approved PRs.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={useSmartTitles}
+                onChange={handleUseSmartTitlesChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OptionsContentGitHub;

--- a/src/options/components/OptionsContentJira.js
+++ b/src/options/components/OptionsContentJira.js
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+
+import {
+  getStoredJiraSettings,
+  setStoredJiraSettings,
+} from "../../utils/storage";
+
+const OptionsContentJira = () => {
+  const [scheduleForToday, setScheduleForToday] = useState(true);
+  const [displayInIssueView, setDisplayInIssueView] = useState(true);
+  const [displayInBoardView, setDisplayInBoardView] = useState(true);
+  const [displayInListView, setDisplayInListView] = useState(true);
+
+  useEffect(() => {
+    getStoredJiraSettings().then((settings) => {
+      if (settings) {
+        setScheduleForToday(settings.scheduleForToday ?? true);
+        setDisplayInIssueView(settings.displayInIssueView ?? true);
+        setDisplayInBoardView(settings.displayInBoardView ?? true);
+        setDisplayInListView(settings.displayInListView ?? true);
+      }
+    });
+  }, []);
+
+  const saveSettings = (newSettings) => {
+    setStoredJiraSettings(newSettings);
+  };
+
+  const handleScheduleForTodayChange = () => {
+    const newValue = !scheduleForToday;
+    setScheduleForToday(newValue);
+    saveSettings({
+      scheduleForToday: newValue,
+      displayInIssueView,
+      displayInBoardView,
+      displayInListView,
+    });
+  };
+
+  const handleDisplayInIssueViewChange = () => {
+    const newValue = !displayInIssueView;
+    setDisplayInIssueView(newValue);
+    saveSettings({
+      scheduleForToday,
+      displayInIssueView: newValue,
+      displayInBoardView,
+      displayInListView,
+    });
+  };
+
+  const handleDisplayInBoardViewChange = () => {
+    const newValue = !displayInBoardView;
+    setDisplayInBoardView(newValue);
+    saveSettings({
+      scheduleForToday,
+      displayInIssueView,
+      displayInBoardView: newValue,
+      displayInListView,
+    });
+  };
+
+  const handleDisplayInListViewChange = () => {
+    const newValue = !displayInListView;
+    setDisplayInListView(newValue);
+    saveSettings({
+      scheduleForToday,
+      displayInIssueView,
+      displayInBoardView,
+      displayInListView: newValue,
+    });
+  };
+
+  return (
+    <>
+      <div className="rounded-lg bg-white shadow-lg text-sm">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Automatically schedule for Today</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When this setting is enabled, Jira issues sent to Marvin as tasks
+              will automatically get scheduled for today.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={scheduleForToday}
+                onChange={handleScheduleForTodayChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display Marvin button in Issue View</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button when viewing individual Jira issues
+              and epics. The button appears in the issue toolbar area.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInIssueView}
+                onChange={handleDisplayInIssueViewChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display Marvin button on Board Cards</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button when hovering over cards on Jira
+              boards (Kanban/Scrum boards). The button appears in the top-right
+              corner of the card.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInBoardView}
+                onChange={handleDisplayInBoardViewChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Display Marvin button in Backlog/List View</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button in the backlog and list views.
+              The button appears in the row actions area.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={displayInListView}
+                onChange={handleDisplayInListViewChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OptionsContentJira;

--- a/src/options/components/OptionsContentSlack.js
+++ b/src/options/components/OptionsContentSlack.js
@@ -1,0 +1,201 @@
+import { useEffect, useState } from "react";
+
+import {
+  getStoredSlackSettings,
+  setStoredSlackSettings,
+} from "../../utils/storage";
+
+const OptionsContentSlack = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [scheduleForToday, setScheduleForToday] = useState(true);
+  const [showInChannels, setShowInChannels] = useState(true);
+  const [showInDMs, setShowInDMs] = useState(true);
+  const [showInThreads, setShowInThreads] = useState(true);
+
+  useEffect(() => {
+    getStoredSlackSettings().then((settings) => {
+      if (settings) {
+        setEnabled(settings.enabled ?? true);
+        setScheduleForToday(settings.scheduleForToday ?? true);
+        setShowInChannels(settings.showInChannels ?? true);
+        setShowInDMs(settings.showInDMs ?? true);
+        setShowInThreads(settings.showInThreads ?? true);
+      }
+    });
+  }, []);
+
+  const saveSettings = (newSettings) => {
+    setStoredSlackSettings(newSettings);
+  };
+
+  const handleEnabledChange = () => {
+    const newValue = !enabled;
+    setEnabled(newValue);
+    saveSettings({
+      enabled: newValue,
+      scheduleForToday,
+      showInChannels,
+      showInDMs,
+      showInThreads,
+    });
+  };
+
+  const handleScheduleForTodayChange = () => {
+    const newValue = !scheduleForToday;
+    setScheduleForToday(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday: newValue,
+      showInChannels,
+      showInDMs,
+      showInThreads,
+    });
+  };
+
+  const handleShowInChannelsChange = () => {
+    const newValue = !showInChannels;
+    setShowInChannels(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday,
+      showInChannels: newValue,
+      showInDMs,
+      showInThreads,
+    });
+  };
+
+  const handleShowInDMsChange = () => {
+    const newValue = !showInDMs;
+    setShowInDMs(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday,
+      showInChannels,
+      showInDMs: newValue,
+      showInThreads,
+    });
+  };
+
+  const handleShowInThreadsChange = () => {
+    const newValue = !showInThreads;
+    setShowInThreads(newValue);
+    saveSettings({
+      enabled,
+      scheduleForToday,
+      showInChannels,
+      showInDMs,
+      showInThreads: newValue,
+    });
+  };
+
+  return (
+    <>
+      <div className="rounded-lg bg-white shadow-lg text-sm">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Enable Slack Integration</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When enabled, "Add to Marvin" buttons will appear on Slack messages
+              allowing you to quickly create tasks from messages.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={handleEnabledChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Automatically schedule for Today</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When this setting is enabled, Slack messages sent to Marvin as tasks
+              will automatically get scheduled for today.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={scheduleForToday}
+                onChange={handleScheduleForTodayChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Show in Channels</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button on messages in public and private
+              channels.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showInChannels}
+                onChange={handleShowInChannelsChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Show in Direct Messages</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button on messages in direct messages (DMs)
+              and group conversations.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showInDMs}
+                onChange={handleShowInDMsChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Show in Threads</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Display "Add to Marvin" button on messages in thread views and
+              replies.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showInThreads}
+                onChange={handleShowInThreadsChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OptionsContentSlack;

--- a/src/options/components/OptionsContentSmartAutocomplete.js
+++ b/src/options/components/OptionsContentSmartAutocomplete.js
@@ -1,0 +1,258 @@
+import { useEffect, useState } from "react";
+
+import {
+  getStoredSmartAutocompleteSettings,
+  setStoredSmartAutocompleteSettings,
+} from "../../utils/storage";
+
+const OptionsContentSmartAutocomplete = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [showSuggestedTitle, setShowSuggestedTitle] = useState(true);
+  const [autoFillTitle, setAutoFillTitle] = useState(false);
+  const [showTimeEstimate, setShowTimeEstimate] = useState(true);
+  const [autoApplyTimeEstimate, setAutoApplyTimeEstimate] = useState(false);
+  const [showLabelSuggestions, setShowLabelSuggestions] = useState(true);
+  const [showPrioritySuggestions, setShowPrioritySuggestions] = useState(true);
+  const [showQuickActions, setShowQuickActions] = useState(true);
+  const [rememberChoices, setRememberChoices] = useState(true);
+
+  useEffect(() => {
+    getStoredSmartAutocompleteSettings().then((settings) => {
+      if (settings) {
+        setEnabled(settings.enabled ?? true);
+        setShowSuggestedTitle(settings.showSuggestedTitle ?? true);
+        setAutoFillTitle(settings.autoFillTitle ?? false);
+        setShowTimeEstimate(settings.showTimeEstimate ?? true);
+        setAutoApplyTimeEstimate(settings.autoApplyTimeEstimate ?? false);
+        setShowLabelSuggestions(settings.showLabelSuggestions ?? true);
+        setShowPrioritySuggestions(settings.showPrioritySuggestions ?? true);
+        setShowQuickActions(settings.showQuickActions ?? true);
+        setRememberChoices(settings.rememberChoices ?? true);
+      }
+    });
+  }, []);
+
+  const saveSettings = (newSettings) => {
+    setStoredSmartAutocompleteSettings(newSettings);
+  };
+
+  const getAllSettings = () => ({
+    enabled,
+    showSuggestedTitle,
+    autoFillTitle,
+    showTimeEstimate,
+    autoApplyTimeEstimate,
+    showLabelSuggestions,
+    showPrioritySuggestions,
+    showQuickActions,
+    rememberChoices,
+    customEstimates: {},
+    userPreferences: {},
+  });
+
+  const handleEnabledChange = () => {
+    const newValue = !enabled;
+    setEnabled(newValue);
+    saveSettings({ ...getAllSettings(), enabled: newValue });
+  };
+
+  const handleShowSuggestedTitleChange = () => {
+    const newValue = !showSuggestedTitle;
+    setShowSuggestedTitle(newValue);
+    saveSettings({ ...getAllSettings(), showSuggestedTitle: newValue });
+  };
+
+  const handleAutoFillTitleChange = () => {
+    const newValue = !autoFillTitle;
+    setAutoFillTitle(newValue);
+    saveSettings({ ...getAllSettings(), autoFillTitle: newValue });
+  };
+
+  const handleShowTimeEstimateChange = () => {
+    const newValue = !showTimeEstimate;
+    setShowTimeEstimate(newValue);
+    saveSettings({ ...getAllSettings(), showTimeEstimate: newValue });
+  };
+
+  const handleAutoApplyTimeEstimateChange = () => {
+    const newValue = !autoApplyTimeEstimate;
+    setAutoApplyTimeEstimate(newValue);
+    saveSettings({ ...getAllSettings(), autoApplyTimeEstimate: newValue });
+  };
+
+  const handleShowLabelSuggestionsChange = () => {
+    const newValue = !showLabelSuggestions;
+    setShowLabelSuggestions(newValue);
+    saveSettings({ ...getAllSettings(), showLabelSuggestions: newValue });
+  };
+
+  const handleShowPrioritySuggestionsChange = () => {
+    const newValue = !showPrioritySuggestions;
+    setShowPrioritySuggestions(newValue);
+    saveSettings({ ...getAllSettings(), showPrioritySuggestions: newValue });
+  };
+
+  const handleShowQuickActionsChange = () => {
+    const newValue = !showQuickActions;
+    setShowQuickActions(newValue);
+    saveSettings({ ...getAllSettings(), showQuickActions: newValue });
+  };
+
+  const handleRememberChoicesChange = () => {
+    const newValue = !rememberChoices;
+    setRememberChoices(newValue);
+    saveSettings({ ...getAllSettings(), rememberChoices: newValue });
+  };
+
+  return (
+    <>
+      <div className="rounded-lg bg-white shadow-lg text-sm">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Enable Smart Autocomplete</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              When enabled, the extension will detect context from platform
+              integrations (GitHub, Jira, Slack, Gmail) and provide smart
+              suggestions for task titles, time estimates, and labels based on
+              the source content.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={handleEnabledChange}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB]"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Title Suggestions</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Show suggested task titles based on the source context (e.g.,
+              "Review PR #123: Title" for GitHub PRs needing review, "PROJ-123:
+              Issue Title" for Jira issues).
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showSuggestedTitle}
+                onChange={handleShowSuggestedTitleChange}
+                disabled={!enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3 pl-4 border-l-2 border-gray-200">
+            <p className="text-gray-600">
+              Automatically fill in the suggested title (instead of showing it
+              as a placeholder). You can still edit it before creating the task.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={autoFillTitle}
+                onChange={handleAutoFillTitleChange}
+                disabled={!enabled || !showSuggestedTitle}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Time Estimate Suggestions</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Suggest time estimates based on the task type (e.g., 30 min for PR
+              reviews, 5 min for merging, 1 hour for fixing CI pipelines).
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showTimeEstimate}
+                onChange={handleShowTimeEstimateChange}
+                disabled={!enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3 pl-4 border-l-2 border-gray-200">
+            <p className="text-gray-600">
+              Automatically apply the suggested time estimate. You can still
+              change it before creating the task.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={autoApplyTimeEstimate}
+                onChange={handleAutoApplyTimeEstimateChange}
+                disabled={!enabled || !showTimeEstimate}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Label Suggestions</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Suggest labels based on context keywords. For example, if a GitHub
+              PR has failing CI, suggest your "bug" or "urgent" labels if you
+              have them.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={showLabelSuggestions}
+                onChange={handleShowLabelSuggestionsChange}
+                disabled={!enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-lg text-sm mt-8 mb-8">
+        <div className="px-6 py-8">
+          <h3 className="font-bold mb-3">Remember Preferences</h3>
+          <div className="flex flex-row items-center justify-between w-full mt-3 mb-3">
+            <p>
+              Remember your choices for each platform/action type. For example,
+              if you always change the suggested time estimate for PR reviews,
+              we'll learn your preference.
+            </p>
+            <label className="relative inline-flex cursor-pointer ml-8">
+              <input
+                type="checkbox"
+                checked={rememberChoices}
+                onChange={handleRememberChoicesChange}
+                disabled={!enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-1 peer-focus:ring-offset-2 peer-focus:ring-[#1CC5CB] rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#1CC5CB] peer-disabled:opacity-50"></div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default OptionsContentSmartAutocomplete;

--- a/src/popup/components/AddTask.js
+++ b/src/popup/components/AddTask.js
@@ -33,6 +33,7 @@ const AddTask = ({ setOnboarded }) => {
   const [displaySettings, setDisplaySettings] = useState({});
 
   const [taskTitle, setTaskTitle] = useState(localStorage.savedTitle || "");
+  const [isAutocompleteOpen, setIsAutocompleteOpen] = useState(false);
   const [note, setNote] = useState(localStorage.savedNote || "");
   const [scheduleDate, setScheduleDate] = useState("unassigned");
   const [scheduleDatePicker, setScheduleDatePicker] = useState({
@@ -347,6 +348,10 @@ const AddTask = ({ setOnboarded }) => {
   const keyUp = useCallback(
     (e) => {
       if (e.which === 13) {
+        // Don't submit if autocomplete is handling the Enter key
+        if (isAutocompleteOpen) {
+          return;
+        }
         if (document.activeElement.tagName === "TEXTAREA") {
           // Don't create when the note is focused
         } else if (taskTitle) {
@@ -356,7 +361,7 @@ const AddTask = ({ setOnboarded }) => {
         }
       }
     },
-    [taskTitle, handleAddTask, setMessage]
+    [taskTitle, handleAddTask, setMessage, isAutocompleteOpen]
   );
 
   const displayElements = () => {
@@ -423,7 +428,11 @@ const AddTask = ({ setOnboarded }) => {
           id="AddTask"
           className="form-control w-full pt-2 pl-5 pr-2 overflow-y-scroll"
         >
-          <AddTaskTitle title={taskTitle} setTaskTitle={setTaskTitle} />
+          <AddTaskTitle
+            title={taskTitle}
+            setTaskTitle={setTaskTitle}
+            onAutocompleteStateChange={setIsAutocompleteOpen}
+          />
 
           {displaySettings?.displayTaskNoteInput && (
             <AddTaskNote note={note} setNote={setNote} />

--- a/src/popup/components/AddTaskDuration.js
+++ b/src/popup/components/AddTaskDuration.js
@@ -1,13 +1,70 @@
+import { BsLightbulb } from "react-icons/bs";
+
 const AddTaskDuration = ({
   timeEstimate,
   setTimeEstimate,
   timeEstimateButtons,
+  suggestedTimeEstimate,
+  taskContext,
 }) => {
+  // Format milliseconds to human-readable duration
+  const formatDuration = (ms) => {
+    if (!ms) return "";
+    const minutes = Math.round(ms / 60000);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    if (remainingMinutes === 0) return `${hours}h`;
+    return `${hours}h ${remainingMinutes}m`;
+  };
+
+  // Check if suggested estimate matches any button
+  const suggestedMatchesButton = timeEstimateButtons.some(
+    (btn) => btn.value === suggestedTimeEstimate
+  );
+
+  // Get platform label
+  const getPlatformLabel = () => {
+    if (!taskContext?.platform) return "context";
+    const labels = {
+      github: "GitHub",
+      jira: "Jira",
+      slack: "Slack",
+      gmail: "Gmail",
+    };
+    return labels[taskContext.platform] || taskContext.platform;
+  };
+
+  // Get action label for tooltip
+  const getActionLabel = () => {
+    if (!taskContext?.action) return "";
+    const actionLabels = {
+      review: "code review",
+      merge: "merging",
+      "fix-pipeline": "fixing CI",
+      "address-review": "addressing review",
+      reply: "replying",
+      "jira-bug": "bug fix",
+      "jira-task": "task",
+      "slack-reply": "Slack reply",
+      "gmail-reply": "email reply",
+    };
+    return actionLabels[taskContext.action] || taskContext.action;
+  };
+
   const buttons = timeEstimateButtons.map((button) => {
     const isChecked = timeEstimate === button.value;
-    const classes = `btn btn-primary btn-xs no-animation ${
+    const isSuggested =
+      suggestedTimeEstimate === button.value && !timeEstimate;
+
+    let classes = `btn btn-primary btn-xs no-animation ${
       isChecked ? "text-white" : "btn-outline"
     }`;
+
+    // Highlight suggested button with a subtle indicator
+    if (isSuggested && !isChecked) {
+      classes += " ring-2 ring-[#1CC5CB] ring-opacity-50";
+    }
 
     return (
       <button
@@ -21,17 +78,40 @@ const AddTaskDuration = ({
 
           setTimeEstimate(button.value);
         }}
+        data-hov={
+          isSuggested
+            ? `Suggested for ${getActionLabel()}`
+            : undefined
+        }
+        data-pos="T"
       >
         {button.text}
+        {isSuggested && (
+          <BsLightbulb size={10} className="ml-0.5 text-[#1CC5CB]" />
+        )}
       </button>
     );
   });
 
   return (
     <div>
-      <label className="label">
-        <span className="label-text text-neutral">Time Estimate</span>
-      </label>
+      <div className="flex flex-row items-center gap-0.5">
+        <label className="label">
+          <span className="label-text text-neutral">Time Estimate</span>
+        </label>
+        {suggestedTimeEstimate && !timeEstimate && !suggestedMatchesButton && (
+          <button
+            type="button"
+            className="flex items-center gap-1 px-2 py-0.5 text-xs bg-gradient-to-r from-[#26d6c4] to-[#10b1d3] text-white rounded-full hover:opacity-90 transition-opacity"
+            onClick={() => setTimeEstimate(suggestedTimeEstimate)}
+            data-hov={`Suggested ${formatDuration(suggestedTimeEstimate)} for ${getActionLabel()} from ${getPlatformLabel()}`}
+            data-pos="T"
+          >
+            <BsLightbulb size={12} />
+            <span>{formatDuration(suggestedTimeEstimate)}</span>
+          </button>
+        )}
+      </div>
 
       <div className="flex flex-wrap gap-1 px-1">{buttons}</div>
     </div>

--- a/src/popup/components/AddTaskLabels.js
+++ b/src/popup/components/AddTaskLabels.js
@@ -1,9 +1,15 @@
 import { useEffect, useState } from "react";
+import { BsLightbulb } from "react-icons/bs";
 import { getStoredLabels } from "../../utils/storage";
 import MarvinLabel from "../../components/MarvinLabel";
 import AddTaskLabelsDropdown from "./AddTaskLabelsDropdown";
 
-const AddTaskLabels = ({ labels, setLabels }) => {
+const AddTaskLabels = ({
+  labels,
+  setLabels,
+  suggestedLabels,
+  taskContext,
+}) => {
   const [allLabels, setAllLabels] = useState([]);
 
   useEffect(() => {
@@ -60,11 +66,64 @@ const AddTaskLabels = ({ labels, setLabels }) => {
     });
   };
 
+  // Apply all suggested labels
+  const applySuggestedLabels = () => {
+    if (!suggestedLabels || suggestedLabels.length === 0) return;
+
+    suggestedLabels.forEach((suggestedLabel) => {
+      // Find the label in allLabels and check it
+      const label = allLabels.find((l) => l._id === suggestedLabel._id);
+      if (label && !label.selected) {
+        checkLabel(label);
+      }
+    });
+  };
+
+  // Check if suggested labels are already applied
+  const suggestedLabelsApplied =
+    !suggestedLabels ||
+    suggestedLabels.length === 0 ||
+    suggestedLabels.every((sl) =>
+      labels.some((l) => l._id === sl._id)
+    );
+
+  // Get platform label
+  const getPlatformLabel = () => {
+    if (!taskContext?.platform) return "context";
+    const platformLabels = {
+      github: "GitHub",
+      jira: "Jira",
+      slack: "Slack",
+      gmail: "Gmail",
+    };
+    return platformLabels[taskContext.platform] || taskContext.platform;
+  };
+
   return (
     <div>
-      <label className="label">
-        <span className="label-text text-neutral">Set Labels</span>
-      </label>
+      <div className="flex flex-row items-center gap-0.5">
+        <label className="label">
+          <span className="label-text text-neutral">Set Labels</span>
+        </label>
+        {suggestedLabels &&
+          suggestedLabels.length > 0 &&
+          !suggestedLabelsApplied && (
+            <button
+              type="button"
+              className="flex items-center gap-1 px-2 py-0.5 text-xs bg-gradient-to-r from-[#26d6c4] to-[#10b1d3] text-white rounded-full hover:opacity-90 transition-opacity"
+              onClick={applySuggestedLabels}
+              data-hov={`Apply suggested labels from ${getPlatformLabel()}`}
+              data-pos="T"
+            >
+              <BsLightbulb size={12} />
+              <span>
+                {suggestedLabels.length === 1
+                  ? suggestedLabels[0].title
+                  : `${suggestedLabels.length} labels`}
+              </span>
+            </button>
+          )}
+      </div>
       <div className="flex flex-wrap gap-y-2">
         {labels.length > 0 &&
           labels.map((label) => {
@@ -85,6 +144,7 @@ const AddTaskLabels = ({ labels, setLabels }) => {
         allLabels={allLabels}
         checkLabel={checkLabel}
         labels={labels}
+        suggestedLabels={suggestedLabels}
       />
     </div>
   );

--- a/src/popup/components/AddTaskLabelsDropdown.js
+++ b/src/popup/components/AddTaskLabelsDropdown.js
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
+import { BsLightbulb } from "react-icons/bs";
 
-const AddTaskLabelsDropdown = ({ allLabels, labels, checkLabel }) => {
+const AddTaskLabelsDropdown = ({
+  allLabels,
+  labels,
+  checkLabel,
+  suggestedLabels,
+}) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredLabels, setFilteredLabels] = useState(allLabels);
@@ -34,6 +40,14 @@ const AddTaskLabelsDropdown = ({ allLabels, labels, checkLabel }) => {
       allLabels.filter((label) =>
         label.title.toLowerCase().includes(query.toLowerCase())
       )
+    );
+  };
+
+  // Check if a label is in the suggested list
+  const isSuggestedLabel = (labelId) => {
+    return (
+      suggestedLabels &&
+      suggestedLabels.some((sl) => sl._id === labelId)
     );
   };
 
@@ -118,9 +132,16 @@ const AddTaskLabelsDropdown = ({ allLabels, labels, checkLabel }) => {
 
             {filteredLabels.length > 0 &&
               filteredLabels.map((label) => {
+                const isSuggested = isSuggestedLabel(label._id);
                 return (
                   <li key={label._id}>
-                    <div className="flex items-center p-2 rounded hover:bg-gray-100">
+                    <div
+                      className={`flex items-center p-2 rounded hover:bg-gray-100 ${
+                        isSuggested && !label.selected
+                          ? "bg-gradient-to-r from-[#26d6c4]/10 to-[#10b1d3]/10"
+                          : ""
+                      }`}
+                    >
                       <input
                         checked={label.selected}
                         onChange={() => checkLabel(label)}
@@ -129,9 +150,16 @@ const AddTaskLabelsDropdown = ({ allLabels, labels, checkLabel }) => {
                       />
                       <label
                         onClick={() => checkLabel(label)}
-                        className="w-full ml-2 text-sm font-medium text-gray-900 rounded"
+                        className="w-full ml-2 text-sm font-medium text-gray-900 rounded flex items-center gap-1"
                       >
                         {label.title}
+                        {isSuggested && !label.selected && (
+                          <BsLightbulb
+                            size={12}
+                            className="text-[#1CC5CB]"
+                            title="Suggested label"
+                          />
+                        )}
                       </label>
                     </div>
                   </li>

--- a/src/popup/components/AddTaskTitle.js
+++ b/src/popup/components/AddTaskTitle.js
@@ -10,6 +10,8 @@ const AddTaskTitle = ({
   suggestedTitle,
   taskContext,
   onApplySuggestion,
+  aiSuggestions,
+  aiLoading,
 }) => {
   const inputRef = useRef(null);
 
@@ -210,6 +212,7 @@ const AddTaskTitle = ({
   // Check if there's a suggested title that differs from the current title
   const hasSuggestion = suggestedTitle && suggestedTitle !== title && !title;
   const showSuggestionIndicator = suggestedTitle && title !== suggestedTitle;
+  const isAISuggestion = aiSuggestions?.isAISuggestion;
 
   // Get platform label for tooltip
   const getPlatformLabel = () => {
@@ -236,16 +239,25 @@ const AddTaskTitle = ({
         <label className="label">
           <span className="label-text text-neutral">Task title</span>
         </label>
-        {showSuggestionIndicator && (
+        {aiLoading && (
+          <span className="flex items-center gap-1 px-2 py-0.5 text-xs text-gray-500">
+            <span className="animate-pulse">Generating AI suggestion...</span>
+          </span>
+        )}
+        {showSuggestionIndicator && !aiLoading && (
           <button
             type="button"
-            className="flex items-center gap-1 px-2 py-0.5 text-xs bg-gradient-to-r from-[#26d6c4] to-[#10b1d3] text-white rounded-full hover:opacity-90 transition-opacity"
+            className={`flex items-center gap-1 px-2 py-0.5 text-xs rounded-full hover:opacity-90 transition-opacity ${
+              isAISuggestion
+                ? "bg-gradient-to-r from-purple-500 to-purple-600 text-white"
+                : "bg-gradient-to-r from-[#26d6c4] to-[#10b1d3] text-white"
+            }`}
             onClick={applySuggestedTitle}
-            data-hov={`Use suggested title from ${getPlatformLabel()}`}
+            data-hov={isAISuggestion ? "AI-generated suggestion" : `Use suggested title from ${getPlatformLabel()}`}
             data-pos="T"
           >
             <BsLightbulb size={12} />
-            <span>Suggestion</span>
+            <span>{isAISuggestion ? "AI Suggestion" : "Suggestion"}</span>
           </button>
         )}
       </div>
@@ -288,14 +300,14 @@ const AddTaskTitle = ({
       </div>
 
       {/* Show suggestion preview when input is empty and there's a suggestion */}
-      {hasSuggestion && (
+      {hasSuggestion && !aiLoading && (
         <div className="mt-1 text-xs text-gray-500">
           <span className="flex items-center gap-1">
-            <BsLightbulb size={10} className="text-[#1CC5CB]" />
-            Click the placeholder or{" "}
+            <BsLightbulb size={10} className={isAISuggestion ? "text-purple-500" : "text-[#1CC5CB]"} />
+            {isAISuggestion ? "AI-generated: " : ""}Click the placeholder or{" "}
             <button
               type="button"
-              className="text-[#1CC5CB] hover:underline"
+              className={`${isAISuggestion ? "text-purple-500" : "text-[#1CC5CB]"} hover:underline`}
               onClick={applySuggestedTitle}
             >
               click here

--- a/src/popup/components/AddTaskTitle.js
+++ b/src/popup/components/AddTaskTitle.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { BsX, BsLightbulb } from "react-icons/bs";
+import { BsX, BsLightbulb, BsStars } from "react-icons/bs";
 import { getStoredCategories, getStoredLabels } from "../../utils/storage";
 import AutocompleteDropdown from "./AutocompleteDropdown";
 
@@ -12,6 +12,9 @@ const AddTaskTitle = ({
   onApplySuggestion,
   aiSuggestions,
   aiLoading,
+  aiError,
+  onFillWithAI,
+  onClearAIError,
 }) => {
   const inputRef = useRef(null);
 
@@ -235,16 +238,65 @@ const AddTaskTitle = ({
 
   return (
     <div>
-      <div className="flex flex-row items-center gap-0.5">
+      <div className="flex flex-row items-center gap-0.5 flex-wrap">
         <label className="label">
           <span className="label-text text-neutral">Task title</span>
         </label>
+
+        {/* Fill with AI Button - shown when not loading and no error */}
+        {onFillWithAI && !aiLoading && !aiError && (
+          <button
+            type="button"
+            className="flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-gradient-to-r from-purple-500 to-purple-600 text-white hover:from-purple-600 hover:to-purple-700 transition-all"
+            onClick={onFillWithAI}
+            data-hov="Generate task details using AI"
+            data-pos="T"
+          >
+            <BsStars size={12} />
+            <span>Fill with AI</span>
+          </button>
+        )}
+
+        {/* AI Loading State */}
         {aiLoading && (
-          <span className="flex items-center gap-1 px-2 py-0.5 text-xs text-gray-500">
-            <span className="animate-pulse">Generating AI suggestion...</span>
+          <span className="flex items-center gap-1 px-2 py-0.5 text-xs text-purple-600 bg-purple-100 rounded-full">
+            <span className="animate-spin">
+              <BsStars size={12} />
+            </span>
+            <span>Generating...</span>
           </span>
         )}
-        {showSuggestionIndicator && !aiLoading && (
+
+        {/* AI Error State */}
+        {aiError && (
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-red-600 bg-red-50 px-2 py-0.5 rounded-full max-w-[200px] truncate" title={aiError}>
+              {aiError}
+            </span>
+            <button
+              type="button"
+              className="flex items-center gap-1 px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200"
+              onClick={() => {
+                onClearAIError?.();
+                onFillWithAI?.();
+              }}
+              data-hov="Retry AI generation"
+              data-pos="T"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              className="text-gray-400 hover:text-gray-600"
+              onClick={onClearAIError}
+            >
+              <BsX size={16} />
+            </button>
+          </div>
+        )}
+
+        {/* Show suggestion badge if AI succeeded and there's a suggestion */}
+        {showSuggestionIndicator && !aiLoading && !aiError && (
           <button
             type="button"
             className={`flex items-center gap-1 px-2 py-0.5 text-xs rounded-full hover:opacity-90 transition-opacity ${

--- a/src/popup/components/AddTaskTitle.js
+++ b/src/popup/components/AddTaskTitle.js
@@ -1,10 +1,204 @@
-import React from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { BsX } from "react-icons/bs";
+import { getStoredCategories, getStoredLabels } from "../../utils/storage";
+import AutocompleteDropdown from "./AutocompleteDropdown";
 
-const AddTaskTitle = ({ title, setTaskTitle }) => {
-  const select = React.useCallback((e) => {
+const AddTaskTitle = ({ title, setTaskTitle, onAutocompleteStateChange }) => {
+  const inputRef = useRef(null);
+
+  const [categories, setCategories] = useState([]);
+  const [labels, setLabels] = useState([]);
+
+  const [autocomplete, setAutocomplete] = useState({
+    visible: false,
+    triggerType: null,
+    triggerStartIndex: null,
+    query: "",
+    selectedIndex: 0,
+  });
+
+  // Load categories and labels on mount
+  useEffect(() => {
+    getStoredCategories().then((cats) => setCategories(cats || []));
+    getStoredLabels().then((lbls) => setLabels(lbls || []));
+  }, []);
+
+  // Notify parent of autocomplete state changes
+  useEffect(() => {
+    if (onAutocompleteStateChange) {
+      onAutocompleteStateChange(autocomplete.visible);
+    }
+  }, [autocomplete.visible, onAutocompleteStateChange]);
+
+  const select = useCallback((e) => {
     e.target.select();
   }, []);
+
+  // Detect trigger characters in the input
+  const detectTrigger = useCallback((value, cursorPosition) => {
+    const beforeCursor = value.slice(0, cursorPosition);
+
+    // Don't trigger inside markdown links: [text](url)
+    const lastOpenBracket = beforeCursor.lastIndexOf("[");
+    const lastCloseBracket = beforeCursor.lastIndexOf("]");
+    if (lastOpenBracket > lastCloseBracket) {
+      return null; // Inside link text
+    }
+    const lastOpenParen = beforeCursor.lastIndexOf("(");
+    const lastCloseParen = beforeCursor.lastIndexOf(")");
+    if (lastOpenParen > lastCloseParen && lastOpenParen > lastCloseBracket) {
+      return null; // Inside link URL
+    }
+
+    // Match trigger character followed by optional word characters
+    const triggerMatch = beforeCursor.match(/([#@+])(\w*)$/);
+    if (triggerMatch) {
+      return {
+        type: triggerMatch[1],
+        query: triggerMatch[2],
+        startIndex: cursorPosition - triggerMatch[0].length,
+      };
+    }
+    return null;
+  }, []);
+
+  // Get filtered suggestions based on trigger type and query
+  const getSuggestions = useCallback(
+    (triggerType, query) => {
+      let items = [];
+
+      if (triggerType === "#" || triggerType === "+") {
+        items = categories.map((cat) => ({ ...cat, type: "category" }));
+      } else if (triggerType === "@") {
+        items = labels.map((label) => ({ ...label, type: "label" }));
+      }
+
+      if (!query) return items.slice(0, 10);
+
+      const lowerQuery = query.toLowerCase();
+      return items
+        .filter((item) => item.title.toLowerCase().includes(lowerQuery))
+        .slice(0, 10);
+    },
+    [categories, labels]
+  );
+
+  // Handle input changes
+  const handleChange = useCallback(
+    (event) => {
+      const value = event.target.value;
+      const cursorPosition = event.target.selectionStart;
+
+      setTaskTitle(value);
+
+      const trigger = detectTrigger(value, cursorPosition);
+
+      if (trigger) {
+        const suggestions = getSuggestions(trigger.type, trigger.query);
+        setAutocomplete({
+          visible: suggestions.length > 0,
+          triggerType: trigger.type,
+          triggerStartIndex: trigger.startIndex,
+          query: trigger.query,
+          selectedIndex: 0,
+        });
+      } else {
+        setAutocomplete((prev) => ({ ...prev, visible: false }));
+      }
+    },
+    [setTaskTitle, detectTrigger, getSuggestions]
+  );
+
+  // Insert the selected suggestion into the title
+  const insertSuggestion = useCallback(
+    (suggestion) => {
+      const { triggerStartIndex, triggerType, query } = autocomplete;
+      const cursorPosition = triggerStartIndex + 1 + query.length;
+
+      const before = title.substring(0, triggerStartIndex);
+      const after = title.substring(cursorPosition);
+
+      // Format: keep the trigger character + title + space
+      const insertText = triggerType + suggestion.title + " ";
+      const newTitle = before + insertText + after.trimStart();
+      const newCursorPosition = before.length + insertText.length;
+
+      setTaskTitle(newTitle);
+      setAutocomplete((prev) => ({ ...prev, visible: false }));
+
+      // Restore focus and cursor position
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.focus();
+          inputRef.current.setSelectionRange(
+            newCursorPosition,
+            newCursorPosition
+          );
+        }
+      }, 0);
+    },
+    [autocomplete, title, setTaskTitle]
+  );
+
+  // Handle keyboard events for dropdown navigation
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (!autocomplete.visible) return;
+
+      const suggestions = getSuggestions(
+        autocomplete.triggerType,
+        autocomplete.query
+      );
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          setAutocomplete((prev) => ({
+            ...prev,
+            selectedIndex: Math.min(prev.selectedIndex + 1, suggestions.length - 1),
+          }));
+          break;
+
+        case "ArrowUp":
+          event.preventDefault();
+          setAutocomplete((prev) => ({
+            ...prev,
+            selectedIndex: Math.max(prev.selectedIndex - 1, 0),
+          }));
+          break;
+
+        case "Enter":
+        case "Tab":
+          if (suggestions.length > 0) {
+            event.preventDefault();
+            event.stopPropagation();
+            insertSuggestion(suggestions[autocomplete.selectedIndex]);
+          }
+          break;
+
+        case "Escape":
+          event.preventDefault();
+          setAutocomplete((prev) => ({ ...prev, visible: false }));
+          break;
+
+        default:
+          break;
+      }
+    },
+    [autocomplete, getSuggestions, insertSuggestion]
+  );
+
+  // Close dropdown on blur (with delay to allow click on dropdown)
+  const handleBlur = useCallback(() => {
+    setTimeout(() => {
+      setAutocomplete((prev) => ({ ...prev, visible: false }));
+    }, 150);
+  }, []);
+
+  // Get current suggestions for rendering
+  const currentSuggestions = autocomplete.visible
+    ? getSuggestions(autocomplete.triggerType, autocomplete.query)
+    : [];
 
   return (
     <div>
@@ -15,15 +209,17 @@ const AddTaskTitle = ({ title, setTaskTitle }) => {
       </div>
       <div className="relative w-full">
         <input
+          ref={inputRef}
           type="text"
           value={title}
-          onChange={(event) => {
-            setTaskTitle(event.target.value);
-          }}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
           placeholder="Enter task title"
           className="input input-bordered input-primary w-full text-base pr-[30px]"
           autoFocus={!title}
           onFocus={select}
+          autoComplete="off"
         />
 
         {title.length > 0 && (
@@ -37,6 +233,14 @@ const AddTaskTitle = ({ title, setTaskTitle }) => {
             <BsX size={24} />
           </button>
         )}
+
+        <AutocompleteDropdown
+          suggestions={currentSuggestions}
+          selectedIndex={autocomplete.selectedIndex}
+          onSelect={insertSuggestion}
+          triggerType={autocomplete.triggerType}
+          visible={autocomplete.visible}
+        />
       </div>
     </div>
   );

--- a/src/popup/components/AutocompleteDropdown.js
+++ b/src/popup/components/AutocompleteDropdown.js
@@ -1,0 +1,58 @@
+import React from "react";
+
+const AutocompleteDropdown = ({
+  suggestions,
+  selectedIndex,
+  onSelect,
+  triggerType,
+  visible,
+}) => {
+  if (!visible || suggestions.length === 0) {
+    return null;
+  }
+
+  const getTypeLabel = () => {
+    switch (triggerType) {
+      case "#":
+        return "Categories";
+      case "@":
+        return "Labels";
+      case "+":
+        return "Projects";
+      default:
+        return "Suggestions";
+    }
+  };
+
+  return (
+    <div className="absolute z-20 bg-white rounded-lg shadow w-full max-h-48 overflow-y-auto mt-1 border border-gray-200">
+      <div className="px-3 py-1 text-xs text-gray-500 border-b border-gray-100">
+        {getTypeLabel()}
+      </div>
+      <ul>
+        {suggestions.map((suggestion, index) => (
+          <li
+            key={suggestion._id}
+            className={`p-2 cursor-pointer flex items-center ${
+              index === selectedIndex ? "bg-gray-100" : "hover:bg-gray-50"
+            }`}
+            onClick={() => onSelect(suggestion)}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {triggerType === "@" && suggestion.color && (
+              <span
+                className="inline-block w-3 h-3 rounded-full mr-2 flex-shrink-0"
+                style={{ backgroundColor: suggestion.color }}
+              />
+            )}
+            <span className="text-sm text-gray-800 truncate">
+              {suggestion.title}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AutocompleteDropdown;

--- a/src/utils/ai.js
+++ b/src/utils/ai.js
@@ -165,6 +165,7 @@ async function callAnthropicAPI(prompt, apiKey, model) {
       'Content-Type': 'application/json',
       'x-api-key': apiKey,
       'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
     },
     body: JSON.stringify({
       model: model,

--- a/src/utils/ai.js
+++ b/src/utils/ai.js
@@ -1,0 +1,222 @@
+/**
+ * AI-Powered Task Suggestions Utility
+ *
+ * Integrates with Anthropic Claude API (Haiku model) to generate
+ * intelligent task suggestions based on source content.
+ */
+
+import {
+  getStoredAISuggestionsSettings,
+  getStoredAISuggestionCache,
+  setStoredAISuggestionCache,
+} from './storage';
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const MODEL = 'claude-3-haiku-20240307';
+const MAX_TOKENS = 250;
+
+/**
+ * Generates a cache key from context
+ */
+function generateCacheKey(context) {
+  const key = `${context.platform}:${context.sourceUrl}:${context.templateKey}`;
+  return btoa(key).substring(0, 32);
+}
+
+/**
+ * Checks if cached suggestion is still valid
+ */
+function isCacheValid(cachedEntry, ttl) {
+  if (!cachedEntry || !cachedEntry.timestamp) return false;
+  return Date.now() - cachedEntry.timestamp < ttl;
+}
+
+/**
+ * Builds the prompt for Claude
+ */
+function buildPrompt(context, userLabels) {
+  const labelNames = userLabels?.map(l => l.title).join(', ') || 'None available';
+
+  return `You are helping create a task from web content. Respond with JSON only, no markdown.
+
+Source platform: ${context.platform || 'unknown'}
+Content type: ${context.action || 'generic'}
+Page title: ${context.metadata?.title || context.metadata?.prTitle || context.metadata?.summary || 'Unknown'}
+Additional context: ${JSON.stringify(context.metadata || {}).substring(0, 500)}
+
+Available labels to choose from: ${labelNames}
+
+Return a JSON object with these exact fields:
+{
+  "title": "Concise actionable task title starting with a verb (max 60 chars)",
+  "timeEstimate": <estimated minutes as integer>,
+  "suggestedLabels": ["label1", "label2"],
+  "priority": "none" | "low" | "medium" | "high",
+  "note": "Brief helpful description (1-2 sentences, optional)"
+}
+
+Rules:
+- Title must start with an action verb (Review, Fix, Respond, Complete, etc.)
+- Only suggest labels from the available list
+- Time estimate should be realistic (5-120 minutes typically)
+- Priority: "high" for urgent/blocking, "medium" for important, "low" for nice-to-have, "none" for routine`;
+}
+
+/**
+ * Parses the AI response into structured suggestions
+ */
+function parseAIResponse(responseText, userLabels) {
+  try {
+    // Try to extract JSON from the response
+    let jsonStr = responseText;
+
+    // Handle potential markdown code blocks
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[0];
+    }
+
+    const parsed = JSON.parse(jsonStr);
+
+    // Validate and sanitize
+    const suggestions = {
+      title: typeof parsed.title === 'string' ? parsed.title.substring(0, 100) : null,
+      timeEstimate: typeof parsed.timeEstimate === 'number'
+        ? parsed.timeEstimate * 60 * 1000 // Convert minutes to ms
+        : null,
+      suggestedLabels: [],
+      priority: ['none', 'low', 'medium', 'high'].includes(parsed.priority)
+        ? parsed.priority
+        : 'none',
+      note: typeof parsed.note === 'string' ? parsed.note.substring(0, 500) : null,
+      isAISuggestion: true,
+    };
+
+    // Map suggested label names to actual label objects
+    if (Array.isArray(parsed.suggestedLabels) && userLabels) {
+      for (const labelName of parsed.suggestedLabels) {
+        const matchedLabel = userLabels.find(
+          l => l.title.toLowerCase() === labelName.toLowerCase()
+        );
+        if (matchedLabel) {
+          suggestions.suggestedLabels.push(matchedLabel);
+        }
+      }
+    }
+
+    return suggestions;
+  } catch (error) {
+    console.error('Failed to parse AI response:', error);
+    return null;
+  }
+}
+
+/**
+ * Calls the Claude API to generate suggestions
+ */
+export async function getAISuggestions(context, userLabels) {
+  const settings = await getStoredAISuggestionsSettings();
+
+  if (!settings.enabled || !settings.apiKey) {
+    return null;
+  }
+
+  // Check cache first
+  if (settings.cacheEnabled) {
+    const cache = await getStoredAISuggestionCache();
+    const cacheKey = generateCacheKey(context);
+    const cachedEntry = cache[cacheKey];
+
+    if (isCacheValid(cachedEntry, settings.cacheTTL)) {
+      return { ...cachedEntry.suggestions, fromCache: true };
+    }
+  }
+
+  try {
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': settings.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        messages: [{
+          role: 'user',
+          content: buildPrompt(context, userLabels),
+        }],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      console.error('Claude API error:', response.status, errorData);
+      return null;
+    }
+
+    const data = await response.json();
+    const responseText = data.content?.[0]?.text;
+
+    if (!responseText) {
+      return null;
+    }
+
+    const suggestions = parseAIResponse(responseText, userLabels);
+
+    // Cache the result
+    if (suggestions && settings.cacheEnabled) {
+      const cache = await getStoredAISuggestionCache();
+      const cacheKey = generateCacheKey(context);
+      cache[cacheKey] = {
+        suggestions,
+        timestamp: Date.now(),
+      };
+
+      // Clean old cache entries
+      const now = Date.now();
+      for (const key of Object.keys(cache)) {
+        if (!isCacheValid(cache[key], settings.cacheTTL)) {
+          delete cache[key];
+        }
+      }
+
+      await setStoredAISuggestionCache(cache);
+    }
+
+    return suggestions;
+  } catch (error) {
+    console.error('Failed to get AI suggestions:', error);
+    return null;
+  }
+}
+
+/**
+ * Verifies an Anthropic API key by making a minimal request
+ */
+export async function verifyAnthropicApiKey(apiKey) {
+  try {
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 10,
+        messages: [{
+          role: 'user',
+          content: 'Say "OK"',
+        }],
+      }),
+    });
+
+    return response.ok;
+  } catch (error) {
+    console.error('API key verification failed:', error);
+    return false;
+  }
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -220,3 +220,25 @@ export function setStoredJiraSettings(settings) {
     });
   });
 }
+
+export function getStoredSlackSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["slackSettings"]).then((result) => {
+      resolve(result.slackSettings || {
+        enabled: true,
+        scheduleForToday: true,
+        showInChannels: true,
+        showInDMs: true,
+        showInThreads: true,
+      });
+    });
+  });
+}
+
+export function setStoredSlackSettings(settings) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ slackSettings: settings }).then(() => {
+      resolve();
+    });
+  });
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -267,3 +267,55 @@ export function setStoredGitHubSettings(settings) {
     });
   });
 }
+
+export function getStoredSmartAutocompleteSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["smartAutocompleteSettings"]).then((result) => {
+      resolve(result.smartAutocompleteSettings || {
+        enabled: true,
+        showSuggestedTitle: true,
+        autoFillTitle: false,
+        showTimeEstimate: true,
+        autoApplyTimeEstimate: false,
+        showLabelSuggestions: true,
+        showPrioritySuggestions: true,
+        showQuickActions: true,
+        rememberChoices: true,
+        customEstimates: {},
+        userPreferences: {},
+      });
+    });
+  });
+}
+
+export function setStoredSmartAutocompleteSettings(settings) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ smartAutocompleteSettings: settings }).then(() => {
+      resolve();
+    });
+  });
+}
+
+export function getStoredTaskContext() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["currentTaskContext"]).then((result) => {
+      resolve(result.currentTaskContext || null);
+    });
+  });
+}
+
+export function setStoredTaskContext(context) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ currentTaskContext: context }).then(() => {
+      resolve();
+    });
+  });
+}
+
+export function clearStoredTaskContext() {
+  return new Promise((resolve) => {
+    chrome.storage.local.remove(["currentTaskContext"]).then(() => {
+      resolve();
+    });
+  });
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -319,3 +319,41 @@ export function clearStoredTaskContext() {
     });
   });
 }
+
+export function getStoredAISuggestionsSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["aiSuggestionsSettings"]).then((result) => {
+      resolve(result.aiSuggestionsSettings || {
+        enabled: false,
+        apiKey: '',
+        showTokenUsage: false,
+        cacheEnabled: true,
+        cacheTTL: 3600000, // 1 hour
+      });
+    });
+  });
+}
+
+export function setStoredAISuggestionsSettings(settings) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ aiSuggestionsSettings: settings }).then(() => {
+      resolve();
+    });
+  });
+}
+
+export function getStoredAISuggestionCache() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["aiSuggestionCache"]).then((result) => {
+      resolve(result.aiSuggestionCache || {});
+    });
+  });
+}
+
+export function setStoredAISuggestionCache(cache) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ aiSuggestionCache: cache }).then(() => {
+      resolve();
+    });
+  });
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -325,6 +325,8 @@ export function getStoredAISuggestionsSettings() {
     chrome.storage.local.get(["aiSuggestionsSettings"]).then((result) => {
       resolve(result.aiSuggestionsSettings || {
         enabled: false,
+        provider: 'anthropic',
+        model: 'claude-3-haiku-20240307',
         apiKey: '',
         showTokenUsage: false,
         cacheEnabled: true,

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -199,3 +199,24 @@ export function setStoredBadgeSettings(settings) {
     });
   });
 }
+
+export function getStoredJiraSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["jiraSettings"]).then((result) => {
+      resolve(result.jiraSettings || {
+        displayInIssueView: true,
+        displayInBoardView: true,
+        displayInListView: true,
+        scheduleForToday: true,
+      });
+    });
+  });
+}
+
+export function setStoredJiraSettings(settings) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ jiraSettings: settings }).then(() => {
+      resolve();
+    });
+  });
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -252,6 +252,9 @@ export function getStoredGitHubSettings() {
         displayInPRView: true,
         displayInPRList: true,
         useSmartTitles: true,
+        displayInComments: true,
+        displayInReviewComments: true,
+        displayInNotifications: true,
       });
     });
   });

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -242,3 +242,25 @@ export function setStoredSlackSettings(settings) {
     });
   });
 }
+
+export function getStoredGitHubSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["githubSettings"]).then((result) => {
+      resolve(result.githubSettings || {
+        enabled: true,
+        scheduleForToday: true,
+        displayInPRView: true,
+        displayInPRList: true,
+        useSmartTitles: true,
+      });
+    });
+  });
+}
+
+export function setStoredGitHubSettings(settings) {
+  return new Promise((resolve) => {
+    chrome.storage.local.set({ githubSettings: settings }).then(() => {
+      resolve();
+    });
+  });
+}

--- a/src/utils/taskContext.js
+++ b/src/utils/taskContext.js
@@ -23,10 +23,10 @@ export const TITLE_TEMPLATES = {
   'github-pr': 'Check PR #{number}: {title}',
 
   // Jira contexts - all start with action verbs
-  'jira-task': 'Complete {key}: {summary}',
+  'jira-task': 'Implement {key}: {summary}',
   'jira-bug': 'Fix {key}: {summary}',
   'jira-story': 'Implement {key}: {summary}',
-  'jira-epic': 'Complete {key}: {summary}',
+  'jira-epic': 'Implement {key}: {summary}',
 
   // Slack contexts - action verbs, no "Re:"
   'slack-reply': 'Respond to [{channel}] {messagePreview}',

--- a/src/utils/taskContext.js
+++ b/src/utils/taskContext.js
@@ -1,0 +1,510 @@
+/**
+ * Task Context Detection and Smart Autocomplete Utility
+ *
+ * Detects source context when task modal opens (which platform/page it came from)
+ * and provides context-aware suggestions for task title, time estimate, labels, and priority.
+ */
+
+// Title templates per context type - all start with action verbs
+export const TITLE_TEMPLATES = {
+  // GitHub contexts
+  'github-review': 'Review PR #{number}: {title}',
+  'github-merge': 'Merge PR #{number}: {title}',
+  'github-fix-pipeline': 'Fix pipelines for PR #{number}: {title}',
+  'github-address-review': 'Address review for PR #{number}: {title}',
+  'github-reply': 'Respond to @{author} on PR #{number}',
+  'github-comment': 'Respond to @{author} on {contextType} #{number}',
+  'github-notification-review': 'Review PR #{number}: {title}',
+  'github-notification-mention': 'Respond to mention in #{number}',
+  'github-notification-assign': 'Work on {contextType} #{number}: {title}',
+  'github-notification-ci': 'Check CI for PR #{number}: {title}',
+  'github-notification': 'Handle {title}',
+  'github-issue': 'Work on Issue #{number}: {title}',
+  'github-pr': 'Check PR #{number}: {title}',
+
+  // Jira contexts - all start with action verbs
+  'jira-task': 'Complete {key}: {summary}',
+  'jira-bug': 'Fix {key}: {summary}',
+  'jira-story': 'Implement {key}: {summary}',
+  'jira-epic': 'Complete {key}: {summary}',
+
+  // Slack contexts - action verbs, no "Re:"
+  'slack-reply': 'Respond to [{channel}] {messagePreview}',
+  'slack-thread': 'Continue thread in [{channel}]',
+  'slack-dm': 'Message {senderName}',
+
+  // Gmail contexts
+  'gmail-reply': 'Reply to: {subject}',
+  'gmail-followup': 'Follow up on: {subject}',
+
+  // Generic
+  'generic': '{title}',
+};
+
+// Default time estimates in milliseconds per action type
+export const DEFAULT_TIME_ESTIMATES = {
+  // GitHub
+  'review': 30 * 60 * 1000,           // 30 min
+  'merge': 5 * 60 * 1000,             // 5 min
+  'fix-pipeline': 60 * 60 * 1000,     // 1 hour
+  'address-review': 45 * 60 * 1000,   // 45 min
+  'reply': 15 * 60 * 1000,            // 15 min
+  'comment': 10 * 60 * 1000,          // 10 min
+
+  // Jira
+  'jira-bug': 60 * 60 * 1000,         // 1 hour
+  'jira-task': 30 * 60 * 1000,        // 30 min
+  'jira-story': 2 * 60 * 60 * 1000,   // 2 hours
+
+  // Slack
+  'slack-reply': 10 * 60 * 1000,      // 10 min
+  'slack-thread': 15 * 60 * 1000,     // 15 min
+
+  // Gmail
+  'gmail-reply': 15 * 60 * 1000,      // 15 min
+  'gmail-followup': 20 * 60 * 1000,   // 20 min
+
+  // Default
+  'default': 30 * 60 * 1000,          // 30 min
+};
+
+// Label keyword mappings for auto-suggestion
+export const LABEL_KEYWORDS = {
+  // GitHub-related
+  'review': ['review', 'code review', 'pr'],
+  'bug': ['bug', 'fix', 'issue', 'error'],
+  'feature': ['feature', 'enhancement', 'new'],
+  'urgent': ['urgent', 'critical', 'high priority', 'blocker'],
+  'documentation': ['docs', 'documentation', 'readme'],
+
+  // Work contexts
+  'meeting': ['meeting', 'call', 'sync'],
+  'email': ['email', 'reply', 'respond'],
+  'slack': ['slack', 'message', 'dm'],
+};
+
+// Priority mappings
+export const PRIORITY_MAPPINGS = {
+  // Jira priorities
+  'highest': 3,    // Red star in Marvin
+  'high': 2,       // Orange star
+  'medium': 1,     // Yellow star
+  'low': 0,
+  'lowest': 0,
+
+  // GitHub
+  'failing-ci': 2, // Orange - needs attention
+  'approved': 1,   // Yellow - ready to merge
+  'review-requested': 2, // Orange - someone is waiting
+};
+
+/**
+ * Detects the platform from a URL
+ * @param {string} url - The URL to analyze
+ * @returns {string|null} - Platform name or null
+ */
+export function detectPlatform(url) {
+  if (!url) return null;
+
+  if (url.includes('github.com')) return 'github';
+  if (url.includes('atlassian.net') || url.includes('jira')) return 'jira';
+  if (url.includes('slack.com') || url.includes('app.slack.com')) return 'slack';
+  if (url.includes('mail.google.com')) return 'gmail';
+
+  return null;
+}
+
+/**
+ * Detects task context from source URL and metadata
+ * @param {string} sourceUrl - The source URL
+ * @param {Object} metadata - Additional metadata from the page
+ * @returns {Object} - Context object with action, template key, and suggestions
+ */
+export function detectTaskContext(sourceUrl, metadata = {}) {
+  const platform = detectPlatform(sourceUrl);
+
+  if (!platform) {
+    return {
+      platform: null,
+      action: 'generic',
+      templateKey: 'generic',
+      suggestedEstimate: DEFAULT_TIME_ESTIMATES.default,
+      suggestedPriority: 0,
+      labelKeywords: [],
+    };
+  }
+
+  switch (platform) {
+    case 'github':
+      return detectGitHubContext(sourceUrl, metadata);
+    case 'jira':
+      return detectJiraContext(sourceUrl, metadata);
+    case 'slack':
+      return detectSlackContext(sourceUrl, metadata);
+    case 'gmail':
+      return detectGmailContext(sourceUrl, metadata);
+    default:
+      return {
+        platform,
+        action: 'generic',
+        templateKey: 'generic',
+        suggestedEstimate: DEFAULT_TIME_ESTIMATES.default,
+        suggestedPriority: 0,
+        labelKeywords: [],
+      };
+  }
+}
+
+/**
+ * Detects GitHub-specific context
+ */
+function detectGitHubContext(sourceUrl, metadata) {
+  const context = {
+    platform: 'github',
+    action: 'generic',
+    templateKey: 'github-pr',
+    suggestedEstimate: DEFAULT_TIME_ESTIMATES.default,
+    suggestedPriority: 0,
+    labelKeywords: [],
+  };
+
+  // Check for PR context
+  if (sourceUrl.includes('/pull/') || metadata.type === 'pr') {
+    // Not own PR - always suggest "Review" regardless of approval status
+    if (!metadata.isOwnPR) {
+      context.action = 'review';
+      context.templateKey = 'github-review';
+      context.suggestedEstimate = DEFAULT_TIME_ESTIMATES.review;
+      context.suggestedPriority = 1;
+      context.labelKeywords = ['review'];
+      return context;
+    }
+
+    // Own PR - check various states
+    // Check pipeline status first (highest priority)
+    if (metadata.checkStatus === 'failing') {
+      context.action = 'fix-pipeline';
+      context.templateKey = 'github-fix-pipeline';
+      context.suggestedEstimate = DEFAULT_TIME_ESTIMATES['fix-pipeline'];
+      context.suggestedPriority = PRIORITY_MAPPINGS['failing-ci'];
+      context.labelKeywords = ['bug', 'urgent'];
+      return context;
+    }
+
+    // Check if changes requested on own PR
+    if (metadata.reviewStatus === 'changes_requested') {
+      context.action = 'address-review';
+      context.templateKey = 'github-address-review';
+      context.suggestedEstimate = DEFAULT_TIME_ESTIMATES['address-review'];
+      context.suggestedPriority = PRIORITY_MAPPINGS['review-requested'];
+      context.labelKeywords = ['review'];
+      return context;
+    }
+
+    // Check if approved and ready to merge (own PR only)
+    if (metadata.reviewStatus === 'approved') {
+      context.action = 'merge';
+      context.templateKey = 'github-merge';
+      context.suggestedEstimate = DEFAULT_TIME_ESTIMATES.merge;
+      context.suggestedPriority = PRIORITY_MAPPINGS.approved;
+      return context;
+    }
+
+    // Default own PR context
+    context.templateKey = 'github-pr';
+    return context;
+  }
+
+  // Check for issue context
+  if (sourceUrl.includes('/issues/') || metadata.type === 'issue') {
+    context.action = 'issue';
+    context.templateKey = 'github-issue';
+    context.labelKeywords = ['bug'];
+    return context;
+  }
+
+  // Check for comment context
+  if (metadata.type === 'comment') {
+    context.action = 'reply';
+    context.templateKey = metadata.contextType === 'pr' ? 'github-reply' : 'github-comment';
+    context.suggestedEstimate = DEFAULT_TIME_ESTIMATES.reply;
+    context.labelKeywords = ['review'];
+    return context;
+  }
+
+  // Check for notification context
+  if (metadata.type === 'notification' || sourceUrl.includes('/notifications')) {
+    switch (metadata.reason) {
+      case 'review_requested':
+        context.action = 'review';
+        context.templateKey = 'github-notification-review';
+        context.suggestedEstimate = DEFAULT_TIME_ESTIMATES.review;
+        context.suggestedPriority = PRIORITY_MAPPINGS['review-requested'];
+        context.labelKeywords = ['review'];
+        break;
+      case 'mention':
+        context.action = 'respond';
+        context.templateKey = 'github-notification-mention';
+        context.suggestedEstimate = DEFAULT_TIME_ESTIMATES.reply;
+        break;
+      case 'assign':
+        context.action = 'work';
+        context.templateKey = 'github-notification-assign';
+        context.suggestedEstimate = DEFAULT_TIME_ESTIMATES.default;
+        break;
+      case 'ci_activity':
+        context.action = 'check-ci';
+        context.templateKey = 'github-notification-ci';
+        context.suggestedEstimate = DEFAULT_TIME_ESTIMATES['fix-pipeline'];
+        break;
+      default:
+        context.templateKey = 'github-notification';
+    }
+    return context;
+  }
+
+  return context;
+}
+
+/**
+ * Detects Jira-specific context
+ */
+function detectJiraContext(sourceUrl, metadata) {
+  const context = {
+    platform: 'jira',
+    action: 'jira-task',
+    templateKey: 'jira-task',
+    suggestedEstimate: DEFAULT_TIME_ESTIMATES['jira-task'],
+    suggestedPriority: 0,
+    labelKeywords: [],
+  };
+
+  // Map issue type to template
+  const issueType = (metadata.issueType || '').toLowerCase();
+
+  if (issueType.includes('bug')) {
+    context.action = 'jira-bug';
+    context.templateKey = 'jira-bug';
+    context.suggestedEstimate = DEFAULT_TIME_ESTIMATES['jira-bug'];
+    context.labelKeywords = ['bug'];
+  } else if (issueType.includes('story')) {
+    context.action = 'jira-story';
+    context.templateKey = 'jira-story';
+    context.suggestedEstimate = DEFAULT_TIME_ESTIMATES['jira-story'];
+    context.labelKeywords = ['feature'];
+  } else if (issueType.includes('epic')) {
+    context.templateKey = 'jira-epic';
+  }
+
+  // Map priority
+  const priority = (metadata.priority || '').toLowerCase();
+  if (priority.includes('highest') || priority.includes('critical')) {
+    context.suggestedPriority = PRIORITY_MAPPINGS.highest;
+    context.labelKeywords.push('urgent');
+  } else if (priority.includes('high')) {
+    context.suggestedPriority = PRIORITY_MAPPINGS.high;
+  } else if (priority.includes('medium')) {
+    context.suggestedPriority = PRIORITY_MAPPINGS.medium;
+  }
+
+  return context;
+}
+
+/**
+ * Detects Slack-specific context
+ */
+function detectSlackContext(sourceUrl, metadata) {
+  const context = {
+    platform: 'slack',
+    action: 'slack-reply',
+    templateKey: 'slack-reply',
+    suggestedEstimate: DEFAULT_TIME_ESTIMATES['slack-reply'],
+    suggestedPriority: 0,
+    labelKeywords: ['slack'],
+  };
+
+  if (metadata.isThread) {
+    context.action = 'slack-thread';
+    context.templateKey = 'slack-thread';
+    context.suggestedEstimate = DEFAULT_TIME_ESTIMATES['slack-thread'];
+  }
+
+  // Check if DM
+  const channelName = (metadata.channelName || '').toLowerCase();
+  if (channelName.includes('direct message') || metadata.isDM) {
+    context.action = 'slack-dm';
+    context.templateKey = 'slack-dm';
+  }
+
+  return context;
+}
+
+/**
+ * Detects Gmail-specific context
+ */
+function detectGmailContext(sourceUrl, metadata) {
+  return {
+    platform: 'gmail',
+    action: 'gmail-reply',
+    templateKey: 'gmail-reply',
+    suggestedEstimate: DEFAULT_TIME_ESTIMATES['gmail-reply'],
+    suggestedPriority: 0,
+    labelKeywords: ['email'],
+  };
+}
+
+/**
+ * Generates a task title from template and metadata
+ * @param {string} templateKey - The template key to use
+ * @param {Object} metadata - The metadata to fill in the template
+ * @returns {string} - The generated title
+ */
+export function generateTitle(templateKey, metadata) {
+  const template = TITLE_TEMPLATES[templateKey] || TITLE_TEMPLATES.generic;
+
+  let title = template;
+
+  // Replace placeholders with metadata values
+  const placeholders = {
+    '{number}': metadata.prNumber || metadata.issueNumber || metadata.contextNumber || '',
+    '{title}': metadata.prTitle || metadata.title || metadata.summary || '',
+    '{author}': metadata.author || metadata.senderName || '',
+    '{key}': metadata.issueKey || '',
+    '{summary}': metadata.summary || metadata.title || '',
+    '{channel}': metadata.channelName || '',
+    '{messagePreview}': truncateText(metadata.messageText || metadata.messagePreview || '', 50),
+    '{senderName}': metadata.senderName || '',
+    '{subject}': metadata.emailSubject || metadata.subject || '',
+    '{contextType}': metadata.contextType === 'pr' ? 'PR' : 'Issue',
+  };
+
+  for (const [placeholder, value] of Object.entries(placeholders)) {
+    title = title.replace(new RegExp(placeholder.replace(/[{}]/g, '\\$&'), 'g'), value);
+  }
+
+  // Clean up any remaining empty placeholders
+  title = title.replace(/\{[^}]+\}/g, '').trim();
+
+  return title;
+}
+
+/**
+ * Truncates text to a specified length
+ */
+function truncateText(text, maxLength) {
+  if (!text || text.length <= maxLength) return text;
+  return text.substring(0, maxLength - 3) + '...';
+}
+
+/**
+ * Generates a formatted title with URL link (Marvin markdown format)
+ * @param {string} templateKey - The template key
+ * @param {Object} metadata - The metadata
+ * @param {string} url - The URL to link to
+ * @returns {string} - The formatted title with link
+ */
+export function generateTitleWithLink(templateKey, metadata, url) {
+  const title = generateTitle(templateKey, metadata);
+
+  if (!url) return title;
+
+  return `[${title}](${url})`;
+}
+
+/**
+ * Suggests labels based on context keywords and user's existing labels
+ * @param {Array} userLabels - The user's existing labels from Marvin
+ * @param {Array} contextKeywords - Keywords from the context
+ * @returns {Array} - Suggested label objects
+ */
+export function suggestLabels(userLabels, contextKeywords) {
+  if (!userLabels || !userLabels.length || !contextKeywords || !contextKeywords.length) {
+    return [];
+  }
+
+  const suggestions = [];
+
+  for (const keyword of contextKeywords) {
+    const keywordLower = keyword.toLowerCase();
+    const keywordMappings = LABEL_KEYWORDS[keywordLower] || [keywordLower];
+
+    for (const label of userLabels) {
+      const labelTitle = (label.title || '').toLowerCase();
+
+      // Check if label matches any of the keyword mappings
+      for (const mapping of keywordMappings) {
+        if (labelTitle.includes(mapping) || mapping.includes(labelTitle)) {
+          if (!suggestions.find((s) => s._id === label._id)) {
+            suggestions.push(label);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return suggestions.slice(0, 3); // Limit to 3 suggestions
+}
+
+/**
+ * Creates a complete task context object from URL and metadata
+ * @param {string} sourceUrl - The source URL
+ * @param {Object} metadata - Page metadata
+ * @param {Object} settings - User's smart autocomplete settings
+ * @returns {Object} - Complete task context with all suggestions
+ */
+export function createTaskContext(sourceUrl, metadata = {}, settings = {}) {
+  const context = detectTaskContext(sourceUrl, metadata);
+
+  // Apply user's custom time estimates if available
+  if (settings.customEstimates && settings.customEstimates[context.action]) {
+    context.suggestedEstimate = settings.customEstimates[context.action];
+  }
+
+  // Generate suggested title
+  context.suggestedTitle = generateTitle(context.templateKey, metadata);
+  context.suggestedTitleWithLink = generateTitleWithLink(
+    context.templateKey,
+    metadata,
+    metadata.url || metadata.prUrl || metadata.issueUrl || metadata.permalink || sourceUrl
+  );
+
+  // Add raw metadata for reference
+  context.metadata = metadata;
+  context.sourceUrl = sourceUrl;
+
+  return context;
+}
+
+/**
+ * Quick action buttons for common task types per platform
+ */
+export const QUICK_ACTIONS = {
+  github: [
+    { action: 'review', label: 'Review', icon: 'eye', templateKey: 'github-review' },
+    { action: 'merge', label: 'Merge', icon: 'git-merge', templateKey: 'github-merge' },
+    { action: 'fix-pipeline', label: 'Fix CI', icon: 'alert-circle', templateKey: 'github-fix-pipeline' },
+    { action: 'reply', label: 'Reply', icon: 'message-circle', templateKey: 'github-reply' },
+  ],
+  jira: [
+    { action: 'jira-task', label: 'Task', icon: 'check-square', templateKey: 'jira-task' },
+    { action: 'jira-bug', label: 'Bug Fix', icon: 'bug', templateKey: 'jira-bug' },
+  ],
+  slack: [
+    { action: 'slack-reply', label: 'Reply', icon: 'message-circle', templateKey: 'slack-reply' },
+    { action: 'slack-thread', label: 'Thread', icon: 'message-square', templateKey: 'slack-thread' },
+  ],
+  gmail: [
+    { action: 'gmail-reply', label: 'Reply', icon: 'mail', templateKey: 'gmail-reply' },
+    { action: 'gmail-followup', label: 'Follow up', icon: 'clock', templateKey: 'gmail-followup' },
+  ],
+};
+
+/**
+ * Gets quick actions for a platform
+ * @param {string} platform - The platform name
+ * @returns {Array} - Array of quick action objects
+ */
+export function getQuickActions(platform) {
+  return QUICK_ACTIONS[platform] || [];
+}


### PR DESCRIPTION
## Summary

Fixes #27 - Popup AI was broken due to race conditions and silent failures. This PR:

- Adds a **"Fill with AI"** button that users click to trigger AI suggestions (replacing broken auto-loading behavior)
- Shows loading state while AI processes, with error messages and retry option on failure
- Adds missing `getPageContext` handler to Gmail content script
- Enhances context gathering for richer AI suggestions:
  - **Slack**: Now includes 5 recent messages for conversation context
  - **GitHub PR**: Extracts linked Jira tickets (PROJ-123 pattern) and review comment stats
  - **Jira**: Includes full description, acceptance criteria, comments preview, and linked issues

## Changes

| File | Changes |
|------|---------|
| `AddTask.js` | Added `handleFillWithAI` callback, removed auto-loading AI behavior |
| `AddTaskTitle.js` | Added "Fill with AI" button with loading/error states |
| `gmail.js` | Added `getPageContext` handler (was completely missing) |
| `slack.js` | Added `getRecentMessages()` for conversation context |
| `github-pr.js` | Added `extractLinkedIssues()` and `getReviewCommentsSummary()` |
| `jira.js` | Added acceptance criteria, comments, and linked issues extraction |

## Test plan

- [ ] Open popup on a GitHub PR page, click "Fill with AI" - should suggest task with PR context
- [ ] Open popup on a Slack conversation, click "Fill with AI" - should include conversation context
- [ ] Open popup on a Jira issue, click "Fill with AI" - should include full description and linked issues
- [ ] Open popup on Gmail, click "Fill with AI" - should work now (previously had no handler)
- [ ] With AI disabled in settings, button should show appropriate error message
- [ ] With invalid/missing API key, button should show error with option to retry
- [ ] Button shows loading spinner while processing
- [ ] Error state has dismiss button to clear error